### PR TITLE
Remove CVS $Id tags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21731,4 +21731,3 @@ Sunday, October 28 2001, James Turner <jmtn@blueyonder.co.uk>
 
 	* Starting changelog from initial attempt to port cyphesis into C++.
 
-$Id$

--- a/aiclient/ClientAccount.cpp
+++ b/aiclient/ClientAccount.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ClientAccount.h"
 

--- a/aiclient/ClientConnection.cpp
+++ b/aiclient/ClientConnection.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ClientConnection.h"
 

--- a/aiclient/client.cpp
+++ b/aiclient/client.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 
 #include "ClientConnection.h"

--- a/client/BaseClient.cpp
+++ b/client/BaseClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "BaseClient.h"
 

--- a/client/BaseClient.h
+++ b/client/BaseClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_BASE_CLIENT_H
 #define CLIENT_BASE_CLIENT_H

--- a/client/CharacterClient.cpp
+++ b/client/CharacterClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CharacterClient.h"
 

--- a/client/CharacterClient.h
+++ b/client/CharacterClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_CHARACTER_CLIENT_H
 #define CLIENT_CHARACTER_CLIENT_H

--- a/client/ClientConnection.cpp
+++ b/client/ClientConnection.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ClientConnection.h"
 

--- a/client/ClientConnection.h
+++ b/client/ClientConnection.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_CLIENT_CONNECTION_H
 #define CLIENT_CLIENT_CONNECTION_H

--- a/client/ClientPropertyManager.cpp
+++ b/client/ClientPropertyManager.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ClientPropertyManager.h"
 

--- a/client/ClientPropertyManager.h
+++ b/client/ClientPropertyManager.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_CLIENT_PROPERTY_MANAGER_H
 #define CLIENT_CLIENT_PROPERTY_MANAGER_H

--- a/client/CreatorClient.cpp
+++ b/client/CreatorClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CreatorClient.h"
 

--- a/client/CreatorClient.h
+++ b/client/CreatorClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_CREATOR_CLIENT_H
 #define CLIENT_CREATOR_CLIENT_H

--- a/client/ObserverClient.cpp
+++ b/client/ObserverClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/client/ObserverClient.h
+++ b/client/ObserverClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_OBSERVER_CLIENT_H
 #define CLIENT_OBSERVER_CLIENT_H

--- a/client/Py_CreatorClient.cpp
+++ b/client/Py_CreatorClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_CreatorClient.h"
 

--- a/client/Py_CreatorClient.h
+++ b/client/Py_CreatorClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_PY_CREATOR_CLIENT_H
 #define CLIENT_PY_CREATOR_CLIENT_H

--- a/client/Py_ObserverClient.cpp
+++ b/client/Py_ObserverClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_ObserverClient.h"
 #include "Py_CreatorClient.h"

--- a/client/Py_ObserverClient.h
+++ b/client/Py_ObserverClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_PY_OBSERVER_CLIENT_H
 #define CLIENT_PY_OBSERVER_CLIENT_H

--- a/client/Python_ClientAPI.cpp
+++ b/client/Python_ClientAPI.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/client/Python_ClientAPI.h
+++ b/client/Python_ClientAPI.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef CLIENT_PYTHON_CLIENT_API_H
 #define CLIENT_PYTHON_CLIENT_API_H

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "client/ClientPropertyManager.h"
 #include "client/Python_ClientAPI.h"

--- a/common/Actuate.h
+++ b/common/Actuate.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ACTUATE_H
 #define COMMON_ACTUATE_H

--- a/common/Add.h
+++ b/common/Add.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ADD_H
 #define COMMON_ADD_H

--- a/common/Affect.h
+++ b/common/Affect.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_AFFECT_H
 #define COMMON_AFFECT_H

--- a/common/AtlasFileLoader.cpp
+++ b/common/AtlasFileLoader.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "common/AtlasFileLoader.h"
 

--- a/common/AtlasFileLoader.h
+++ b/common/AtlasFileLoader.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ATLAS_FILE_LOADER_H
 #define COMMON_ATLAS_FILE_LOADER_H

--- a/common/AtlasStreamClient.cpp
+++ b/common/AtlasStreamClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/AtlasStreamClient.h
+++ b/common/AtlasStreamClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ATLAS_STREAM_CLIENT_H
 #define COMMON_ATLAS_STREAM_CLIENT_H

--- a/common/Attack.h
+++ b/common/Attack.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ATTACK_H
 #define COMMON_ATTACK_H

--- a/common/BaseWorld.cpp
+++ b/common/BaseWorld.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "BaseWorld.h"
 

--- a/common/BaseWorld.h
+++ b/common/BaseWorld.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_BASE_WORLD_H
 #define COMMON_BASE_WORLD_H

--- a/common/Burn.h
+++ b/common/Burn.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_BURN_H
 #define COMMON_BURN_H

--- a/common/ClientTask.cpp
+++ b/common/ClientTask.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ClientTask.h"
 

--- a/common/ClientTask.h
+++ b/common/ClientTask.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_CLIENT_TASK_H
 #define COMMON_CLIENT_TASK_H

--- a/common/CommSocket.cpp
+++ b/common/CommSocket.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommSocket.h"
 

--- a/common/CommSocket.h
+++ b/common/CommSocket.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_COMM_SOCKET_H
 #define COMMON_COMM_SOCKET_H

--- a/common/Connect.h
+++ b/common/Connect.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_CONNECT_H
 #define COMMON_CONNECT_H

--- a/common/Database.cpp
+++ b/common/Database.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Database.h"
 

--- a/common/Database.h
+++ b/common/Database.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_DATABASE_H
 #define COMMON_DATABASE_H

--- a/common/Drop.h
+++ b/common/Drop.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_DROP_H
 #define COMMON_DROP_H

--- a/common/Eat.h
+++ b/common/Eat.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_EAT_H
 #define COMMON_EAT_H

--- a/common/EntityKit.cpp
+++ b/common/EntityKit.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityKit.h"
 

--- a/common/EntityKit.h
+++ b/common/EntityKit.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ENTITY_KIT_H
 #define COMMON_ENTITY_KIT_H

--- a/common/FormattedXMLWriter.cpp
+++ b/common/FormattedXMLWriter.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "FormattedXMLWriter.h"
 

--- a/common/FormattedXMLWriter.h
+++ b/common/FormattedXMLWriter.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_FORMATTED_XML_WRITER_H
 #define COMMON_FORMATTED_XML_WRITER_H

--- a/common/Inheritance.cpp
+++ b/common/Inheritance.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Inheritance.h"
 

--- a/common/Inheritance.h
+++ b/common/Inheritance.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_INHERITANCE_H
 #define COMMON_INHERITANCE_H

--- a/common/Link.cpp
+++ b/common/Link.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Link.h"
 

--- a/common/Link.h
+++ b/common/Link.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_LINK_H
 #define COMMON_LINK_H

--- a/common/Monitor.h
+++ b/common/Monitor.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_MONITOR_H
 #define COMMON_MONITOR_H

--- a/common/Monitors.cpp
+++ b/common/Monitors.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Monitors.h"
 

--- a/common/Monitors.h
+++ b/common/Monitors.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_MONITORS_H
 #define COMMON_MONITORS_H

--- a/common/Nourish.h
+++ b/common/Nourish.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_NOURISH_H
 #define COMMON_NOURISH_H

--- a/common/OperationRouter.cpp
+++ b/common/OperationRouter.cpp
@@ -15,6 +15,5 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "OperationRouter.h"

--- a/common/OperationRouter.h
+++ b/common/OperationRouter.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_OPERATION_ROUTER_H
 #define COMMON_OPERATION_ROUTER_H

--- a/common/Pickup.h
+++ b/common/Pickup.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PICKUP_H
 #define COMMON_PICKUP_H

--- a/common/Property.cpp
+++ b/common/Property.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Property_impl.h"
 

--- a/common/Property.h
+++ b/common/Property.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PROPERTY_H
 #define COMMON_PROPERTY_H

--- a/common/PropertyFactory.cpp
+++ b/common/PropertyFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "PropertyFactory_impl.h"
 

--- a/common/PropertyFactory.h
+++ b/common/PropertyFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PROPERTY_FACTORY_H
 #define COMMON_PROPERTY_FACTORY_H

--- a/common/PropertyFactory_impl.h
+++ b/common/PropertyFactory_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PROPERTY_FACTORY_IMPL_H
 #define COMMON_PROPERTY_FACTORY_IMPL_H

--- a/common/PropertyManager.cpp
+++ b/common/PropertyManager.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "PropertyManager.h"
 

--- a/common/PropertyManager.h
+++ b/common/PropertyManager.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PROPERTY_MANAGER_H
 #define COMMON_PROPERTY_MANAGER_H

--- a/common/Property_impl.h
+++ b/common/Property_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_PROPERTY_IMPL_H
 #define COMMON_PROPERTY_IMPL_H

--- a/common/Router.cpp
+++ b/common/Router.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Router.h"
 

--- a/common/Router.h
+++ b/common/Router.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ROUTER_H
 #define COMMON_ROUTER_H

--- a/common/ScriptKit.cpp
+++ b/common/ScriptKit.cpp
@@ -15,6 +15,5 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ScriptKit.h"

--- a/common/ScriptKit.h
+++ b/common/ScriptKit.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SCRIPT_KIT_H
 #define COMMON_SCRIPT_KIT_H

--- a/common/Setup.h
+++ b/common/Setup.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SETUP_H
 #define COMMON_SETUP_H

--- a/common/Shaker.cpp
+++ b/common/Shaker.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Shaker.h"
 

--- a/common/Shaker.h
+++ b/common/Shaker.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SHAKER_H
 #define COMMON_SHAKER_H

--- a/common/Storage.cpp
+++ b/common/Storage.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Storage.h"
 

--- a/common/Storage.h
+++ b/common/Storage.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_STORAGE_H
 #define COMMON_STORAGE_H

--- a/common/SystemTime.cpp
+++ b/common/SystemTime.cpp
@@ -15,6 +15,5 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SystemTime.h"

--- a/common/SystemTime.h
+++ b/common/SystemTime.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SYSTEM_TIME_H
 #define COMMON_SYSTEM_TIME_H

--- a/common/TaskKit.cpp
+++ b/common/TaskKit.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TaskKit.h"
 

--- a/common/TaskKit.h
+++ b/common/TaskKit.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TASK_KIT_H
 #define COMMON_TASK_KIT_H

--- a/common/Teleport.h
+++ b/common/Teleport.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TELEPORT_H
 #define COMMON_TELEPORT_H

--- a/common/Tick.h
+++ b/common/Tick.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TICK_H
 #define COMMON_TICK_H

--- a/common/TypeNode.cpp
+++ b/common/TypeNode.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TypeNode.h"
 

--- a/common/TypeNode.h
+++ b/common/TypeNode.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TYPE_NODE_H
 #define COMMON_TYPE_NODE_H

--- a/common/Unseen.h
+++ b/common/Unseen.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_UNSEEN_H
 #define COMMON_UNSEEN_H

--- a/common/Update.h
+++ b/common/Update.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_UPDATE_H
 #define COMMON_UPDATE_H

--- a/common/Variable.cpp
+++ b/common/Variable.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Variable.h"
 

--- a/common/Variable.h
+++ b/common/Variable.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_VARIABLE_H
 #define COMMON_VARIABLE_H

--- a/common/atlas_helpers.cpp
+++ b/common/atlas_helpers.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "atlas_helpers.h"
 

--- a/common/atlas_helpers.h
+++ b/common/atlas_helpers.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ATLAS_HELPERS_H
 #define COMMON_ATLAS_HELPERS_H

--- a/common/client_socket.cpp
+++ b/common/client_socket.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "sockets.h"
 #include "globals.h"

--- a/common/const.cpp
+++ b/common/const.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/const.h
+++ b/common/const.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_CONST_H
 #define COMMON_CONST_H

--- a/common/custom.cpp
+++ b/common/custom.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Inheritance.h"
 

--- a/common/custom.h
+++ b/common/custom.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_CUSTOM_H
 #define COMMON_CUSTOM_H

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "debug.h"
 

--- a/common/debug.h
+++ b/common/debug.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_DEBUG_H
 #define COMMON_DEBUG_H

--- a/common/globals.cpp
+++ b/common/globals.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/globals.h
+++ b/common/globals.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_GLOBALS_H
 #define COMMON_GLOBALS_H

--- a/common/id.cpp
+++ b/common/id.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "common/id.h"
 #include "common/log.h"

--- a/common/id.h
+++ b/common/id.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_ID_H
 #define COMMON_ID_H

--- a/common/log.cpp
+++ b/common/log.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/log.h
+++ b/common/log.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_LOG_H
 #define COMMON_LOG_H

--- a/common/newid.cpp
+++ b/common/newid.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "common/id.h"
 #include "common/globals.h"

--- a/common/nls.h
+++ b/common/nls.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_NLS_H
 #define COMMON_NLS_H

--- a/common/op_switch.h
+++ b/common/op_switch.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_OP_SWITCH_H
 #define COMMON_OP_SWITCH_H

--- a/common/operations.cpp
+++ b/common/operations.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \brief Operation classes not defined in the Atlas spec
 ///

--- a/common/random.h
+++ b/common/random.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_RANDOM_H
 #define COMMON_RANDOM_H

--- a/common/serialno.cpp
+++ b/common/serialno.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "serialno.h"
 

--- a/common/serialno.h
+++ b/common/serialno.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SERIALNO_H
 #define COMMON_SERIALNO_H

--- a/common/sockets.h
+++ b/common/sockets.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SOCKETS_H
 #define COMMON_SOCKETS_H

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/system.h
+++ b/common/system.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_SYSTEM_H
 #define COMMON_SYSTEM_H

--- a/common/system_net.cpp
+++ b/common/system_net.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/system_prefix.cpp
+++ b/common/system_prefix.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/system_uid.cpp
+++ b/common/system_uid.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/common/type_utils.cpp
+++ b/common/type_utils.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "common/type_utils_impl.h"
 

--- a/common/type_utils.h
+++ b/common/type_utils.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TYPE_UTILS_H
 #define COMMON_TYPE_UTILS_H

--- a/common/type_utils_impl.h
+++ b/common/type_utils_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TYPE_UTILS_IMPL_H
 #define COMMON_TYPE_UTILS_IMPL_H

--- a/common/types.h
+++ b/common/types.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_TYPES_H
 #define COMMON_TYPES_H

--- a/common/utils.h
+++ b/common/utils.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef COMMON_UTILS_H
 #define COMMON_UTILS_H

--- a/modules/DateTime.cpp
+++ b/modules/DateTime.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "DateTime.h"
 

--- a/modules/DateTime.h
+++ b/modules/DateTime.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef MODULES_DATE_TIME_H
 #define MODULES_DATE_TIME_H

--- a/modules/EntityRef.cpp
+++ b/modules/EntityRef.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityRef.h"
 

--- a/modules/EntityRef.h
+++ b/modules/EntityRef.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef MODULES_ENTITY_REF_H
 #define MODULES_ENTITY_REF_H

--- a/modules/Location.cpp
+++ b/modules/Location.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/LocatedEntity.h"
 

--- a/modules/Location.h
+++ b/modules/Location.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef MODULES_LOCATION_H
 #define MODULES_LOCATION_H

--- a/modules/TerrainContext.cpp
+++ b/modules/TerrainContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "modules/TerrainContext.h"
 

--- a/modules/TerrainContext.h
+++ b/modules/TerrainContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef MODULES_TERRAIN_CONTEXT_H
 #define MODULES_TERRAIN_CONTEXT_H

--- a/modules/WorldTime.cpp
+++ b/modules/WorldTime.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "WorldTime.h"
 

--- a/modules/WorldTime.h
+++ b/modules/WorldTime.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef MODULES_WORLD_TIME_H
 #define MODULES_WORLD_TIME_H

--- a/physics/BBox.cpp
+++ b/physics/BBox.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "BBox.h"
 

--- a/physics/BBox.h
+++ b/physics/BBox.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_B_BOX_H
 #define PHYSICS_B_BOX_H

--- a/physics/Collision.cpp
+++ b/physics/Collision.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Collision.h"
 

--- a/physics/Collision.h
+++ b/physics/Collision.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_COLLISION_H
 #define PHYSICS_COLLISION_H

--- a/physics/Course.cpp
+++ b/physics/Course.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Course_impl.h"
 

--- a/physics/Course.h
+++ b/physics/Course.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_COURSE_H
 #define PHYSICS_COURSE_H

--- a/physics/Course_impl.h
+++ b/physics/Course_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_COURSE_IMPL_H
 #define PHYSICS_COURSE_IMPL_H

--- a/physics/Quaternion.cpp
+++ b/physics/Quaternion.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Quaternion.h"
 

--- a/physics/Quaternion.h
+++ b/physics/Quaternion.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_QUATERNION_H
 #define PHYSICS_QUATERNION_H

--- a/physics/Shape.cpp
+++ b/physics/Shape.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Shape_impl.h"
 #include "Course.h"

--- a/physics/Shape.h
+++ b/physics/Shape.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_SHAPE_H
 #define PHYSICS_SHAPE_H

--- a/physics/Shape_impl.h
+++ b/physics/Shape_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_SHAPE_IMPL_H
 #define PHYSICS_SHAPE_IMPL_H

--- a/physics/Vector3D.cpp
+++ b/physics/Vector3D.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 // Remember kids, it takes 7 times longer to call mag() than to call relMag(),
 // so if you are comparing vector magnitudes, always use relMag().

--- a/physics/Vector3D.h
+++ b/physics/Vector3D.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef PHYSICS_VECTOR_3D_H
 #define PHYSICS_VECTOR_3D_H

--- a/rulesets/AreaProperty.cpp
+++ b/rulesets/AreaProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "AreaProperty.h"
 

--- a/rulesets/AreaProperty.h
+++ b/rulesets/AreaProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_AREA_PROPERTY_H
 #define RULESETS_AREA_PROPERTY_H

--- a/rulesets/ArithmeticFactory.cpp
+++ b/rulesets/ArithmeticFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/ArithmeticFactory.h"
 

--- a/rulesets/ArithmeticFactory.h
+++ b/rulesets/ArithmeticFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_ARITHMETIC_FACTORY_H
 #define RULESETS_ARITHMETIC_FACTORY_H

--- a/rulesets/ArithmeticScript.cpp
+++ b/rulesets/ArithmeticScript.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/ArithmeticScript.h"
 

--- a/rulesets/ArithmeticScript.h
+++ b/rulesets/ArithmeticScript.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_ARITHMETIC_SCRIPT_H
 #define RULESETS_ARITHMETIC_SCRIPT_H

--- a/rulesets/AtlasProperties.cpp
+++ b/rulesets/AtlasProperties.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "AtlasProperties.h"
 

--- a/rulesets/AtlasProperties.h
+++ b/rulesets/AtlasProperties.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_ATLAS_PROPERTIES_H
 #define RULESETS_ATLAS_PROPERTIES_H

--- a/rulesets/BBoxProperty.cpp
+++ b/rulesets/BBoxProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "BBoxProperty.h"
 

--- a/rulesets/BBoxProperty.h
+++ b/rulesets/BBoxProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_B_BOX_PROPERTY_H
 #define RULESETS_B_BOX_PROPERTY_H

--- a/rulesets/BaseMind.cpp
+++ b/rulesets/BaseMind.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "BaseMind.h"
 

--- a/rulesets/BaseMind.h
+++ b/rulesets/BaseMind.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_BASE_MIND_H
 #define RULESETS_BASE_MIND_H

--- a/rulesets/BiomassProperty.cpp
+++ b/rulesets/BiomassProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/BiomassProperty.h"
 

--- a/rulesets/BiomassProperty.h
+++ b/rulesets/BiomassProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_BIOMASS_PROPERTY_H
 #define RULESETS_BIOMASS_PROPERTY_H

--- a/rulesets/BulletDomain.cpp
+++ b/rulesets/BulletDomain.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/rulesets/BulletDomain.h
+++ b/rulesets/BulletDomain.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_BULLET_DOMAIN_H
 #define RULESETS_BULLET_DOMAIN_H

--- a/rulesets/BurnSpeedProperty.cpp
+++ b/rulesets/BurnSpeedProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/BurnSpeedProperty.h"
 

--- a/rulesets/BurnSpeedProperty.h
+++ b/rulesets/BurnSpeedProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_BURN_SPEED_PROPERTY_H
 #define RULESETS_BURN_SPEED_PROPERTY_H

--- a/rulesets/CalendarProperty.cpp
+++ b/rulesets/CalendarProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CalendarProperty.h"
 

--- a/rulesets/CalendarProperty.h
+++ b/rulesets/CalendarProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_CALENDAR_PROPERTY_H
 #define RULESETS_CALENDAR_PROPERTY_H

--- a/rulesets/Character.cpp
+++ b/rulesets/Character.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Character.h"
 

--- a/rulesets/Character.h
+++ b/rulesets/Character.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_CHARACTER_H
 #define RULESETS_CHARACTER_H

--- a/rulesets/Container.cpp
+++ b/rulesets/Container.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Container.h"
 

--- a/rulesets/Container.h
+++ b/rulesets/Container.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_CONTAINER_H
 #define RULESETS_CONTAINER_H

--- a/rulesets/Creator.cpp
+++ b/rulesets/Creator.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Creator.h"
 

--- a/rulesets/Creator.h
+++ b/rulesets/Creator.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_CREATOR_H
 #define RULESETS_CREATOR_H

--- a/rulesets/DecaysProperty.cpp
+++ b/rulesets/DecaysProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/DecaysProperty.h"
 

--- a/rulesets/DecaysProperty.h
+++ b/rulesets/DecaysProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_DECAYS_PROPERTY_H
 #define RULESETS_DECAYS_PROPERTY_H

--- a/rulesets/Domain.cpp
+++ b/rulesets/Domain.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Domain.h"
 #include "TerrainProperty.h"

--- a/rulesets/Domain.h
+++ b/rulesets/Domain.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_DOMAIN_H
 #define RULESETS_DOMAIN_H

--- a/rulesets/Entity.cpp
+++ b/rulesets/Entity.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Entity.h"
 

--- a/rulesets/Entity.h
+++ b/rulesets/Entity.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_ENTITY_H
 #define RULESETS_ENTITY_H

--- a/rulesets/EntityProperties.cpp
+++ b/rulesets/EntityProperties.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "LocatedEntity.h"
 

--- a/rulesets/EntityProperty.cpp
+++ b/rulesets/EntityProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityProperty.h"
 

--- a/rulesets/EntityProperty.h
+++ b/rulesets/EntityProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_ENTITY_PROPERTY_H
 #define RULESETS_ENTITY_PROPERTY_H

--- a/rulesets/EntityPropertyFactory.cpp
+++ b/rulesets/EntityPropertyFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #error This file has been removed from the build.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rulesets/EntityPropertyFactory.h
+++ b/rulesets/EntityPropertyFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #error This file has been removed from the build
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rulesets/EntityPropertyFactory_impl.h
+++ b/rulesets/EntityPropertyFactory_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #error This file has been removed from the build
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rulesets/ExternalMind.cpp
+++ b/rulesets/ExternalMind.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ExternalMind.h"
 

--- a/rulesets/ExternalMind.h
+++ b/rulesets/ExternalMind.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_EXTERNAL_MIND_H
 #define RULESETS_EXTERNAL_MIND_H

--- a/rulesets/ExternalProperty.cpp
+++ b/rulesets/ExternalProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ExternalProperty.h"
 

--- a/rulesets/ExternalProperty.h
+++ b/rulesets/ExternalProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_EXTERNAL_PROPERTY_H
 #define RULESETS_EXTERNAL_PROPERTY_H

--- a/rulesets/InternalProperties.cpp
+++ b/rulesets/InternalProperties.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "InternalProperties.h"
 

--- a/rulesets/InternalProperties.h
+++ b/rulesets/InternalProperties.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_INTERNAL_PROPERTIES_H
 #define RULESETS_INTERNAL_PROPERTIES_H

--- a/rulesets/LineProperty.cpp
+++ b/rulesets/LineProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "LineProperty.h"
 

--- a/rulesets/LineProperty.h
+++ b/rulesets/LineProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_LINE_PROPERTY_H
 #define RULESETS_LINE_PROPERTY_H

--- a/rulesets/LocatedEntity.cpp
+++ b/rulesets/LocatedEntity.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "LocatedEntity.h"
 

--- a/rulesets/LocatedEntity.h
+++ b/rulesets/LocatedEntity.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_LOCATED_ENTITY_H
 #define RULESETS_LOCATED_ENTITY_H

--- a/rulesets/MemEntity.cpp
+++ b/rulesets/MemEntity.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "MemEntity.h"
 #include "rulesets/BBoxProperty.h"

--- a/rulesets/MemEntity.h
+++ b/rulesets/MemEntity.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MEM_ENTITY_H
 #define RULESETS_MEM_ENTITY_H

--- a/rulesets/MemMap.cpp
+++ b/rulesets/MemMap.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "MemMap.h"
 

--- a/rulesets/MemMap.h
+++ b/rulesets/MemMap.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MEM_MAP_H
 #define RULESETS_MEM_MAP_H

--- a/rulesets/MindFactory.cpp
+++ b/rulesets/MindFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "MindFactory.h"
 

--- a/rulesets/MindFactory.h
+++ b/rulesets/MindFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MIND_FACTORY_H
 #define RULESETS_MIND_FACTORY_H

--- a/rulesets/MindProperty.cpp
+++ b/rulesets/MindProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "MindProperty.h"
 

--- a/rulesets/MindProperty.h
+++ b/rulesets/MindProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MIND_PROPERTY_H
 #define RULESETS_MIND_PROPERTY_H

--- a/rulesets/Motion.cpp
+++ b/rulesets/Motion.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Motion.h"
 

--- a/rulesets/Motion.h
+++ b/rulesets/Motion.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MOTION_H
 #define RULESETS_MOTION_H

--- a/rulesets/Movement.cpp
+++ b/rulesets/Movement.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Movement.h"
 

--- a/rulesets/Movement.h
+++ b/rulesets/Movement.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_MOVEMENT_H
 #define RULESETS_MOVEMENT_H

--- a/rulesets/OutfitProperty.cpp
+++ b/rulesets/OutfitProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "OutfitProperty.h"
 

--- a/rulesets/OutfitProperty.h
+++ b/rulesets/OutfitProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_OUTFIT_PROPERTY_H
 #define RULESETS_OUTFIT_PROPERTY_H

--- a/rulesets/Pedestrian.cpp
+++ b/rulesets/Pedestrian.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Pedestrian.h"
 

--- a/rulesets/Pedestrian.h
+++ b/rulesets/Pedestrian.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PEDESTRIAN_H
 #define RULESETS_PEDESTRIAN_H

--- a/rulesets/Plant.cpp
+++ b/rulesets/Plant.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Plant.h"
 

--- a/rulesets/Plant.h
+++ b/rulesets/Plant.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PLANT_H
 #define RULESETS_PLANT_H

--- a/rulesets/Py_BBox.cpp
+++ b/rulesets/Py_BBox.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_BBox.h"
 

--- a/rulesets/Py_BBox.h
+++ b/rulesets/Py_BBox.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_B_BOX_H
 #define RULESETS_PY_B_BOX_H

--- a/rulesets/Py_EntityWrapper.h
+++ b/rulesets/Py_EntityWrapper.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_ENTITY_WRAPPER_H
 #define RULESETS_PY_ENTITY_WRAPPER_H

--- a/rulesets/Py_Location.cpp
+++ b/rulesets/Py_Location.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Location.h"
 #include "Py_Thing.h"

--- a/rulesets/Py_Location.h
+++ b/rulesets/Py_Location.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_LOCATION_H
 #define RULESETS_PY_LOCATION_H

--- a/rulesets/Py_Map.cpp
+++ b/rulesets/Py_Map.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Map.h"
 #include "Py_Location.h"

--- a/rulesets/Py_Map.h
+++ b/rulesets/Py_Map.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_MAP_H
 #define RULESETS_PY_MAP_H

--- a/rulesets/Py_Message.cpp
+++ b/rulesets/Py_Message.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Message.h"
 #include "Py_Operation.h"

--- a/rulesets/Py_Message.h
+++ b/rulesets/Py_Message.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_MESSAGE_H
 #define RULESETS_PY_MESSAGE_H

--- a/rulesets/Py_Operation.cpp
+++ b/rulesets/Py_Operation.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Operation.h"
 #include "Py_RootEntity.h"

--- a/rulesets/Py_Operation.h
+++ b/rulesets/Py_Operation.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_OPERATION_H
 #define RULESETS_PY_OPERATION_H

--- a/rulesets/Py_Oplist.cpp
+++ b/rulesets/Py_Oplist.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Operation.h"
 #include "Py_Oplist.h"

--- a/rulesets/Py_Oplist.h
+++ b/rulesets/Py_Oplist.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_OPLIST_H
 #define RULESETS_PY_OPLIST_H

--- a/rulesets/Py_Point3D.cpp
+++ b/rulesets/Py_Point3D.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Point3D.h"
 

--- a/rulesets/Py_Point3D.h
+++ b/rulesets/Py_Point3D.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_POINT_3D_H
 #define RULESETS_PY_POINT_3D_H

--- a/rulesets/Py_Property.cpp
+++ b/rulesets/Py_Property.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Property.h"
 

--- a/rulesets/Py_Property.h
+++ b/rulesets/Py_Property.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_PROPERTY_H
 #define RULESETS_PY_PROPERTY_H

--- a/rulesets/Py_Quaternion.cpp
+++ b/rulesets/Py_Quaternion.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Quaternion.h"
 

--- a/rulesets/Py_Quaternion.h
+++ b/rulesets/Py_Quaternion.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_QUATERNION_H
 #define RULESETS_PY_QUATERNION_H

--- a/rulesets/Py_RootEntity.cpp
+++ b/rulesets/Py_RootEntity.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_RootEntity.h"
 #include "Py_Message.h"

--- a/rulesets/Py_RootEntity.h
+++ b/rulesets/Py_RootEntity.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_ROOT_ENTITY_H
 #define RULESETS_PY_ROOT_ENTITY_H

--- a/rulesets/Py_Shape.cpp
+++ b/rulesets/Py_Shape.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Shape.h"
 

--- a/rulesets/Py_Shape.h
+++ b/rulesets/Py_Shape.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_SHAPE_H
 #define RULESETS_PY_SHAPE_H

--- a/rulesets/Py_Task.cpp
+++ b/rulesets/Py_Task.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Task.h"
 

--- a/rulesets/Py_Task.h
+++ b/rulesets/Py_Task.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_TASK_H
 #define RULESETS_PY_TASK_H

--- a/rulesets/Py_TerrainModProperty.cpp
+++ b/rulesets/Py_TerrainModProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Property.h"
 

--- a/rulesets/Py_TerrainProperty.cpp
+++ b/rulesets/Py_TerrainProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Property.h"
 

--- a/rulesets/Py_Thing.cpp
+++ b/rulesets/Py_Thing.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Thing.h"
 

--- a/rulesets/Py_Thing.h
+++ b/rulesets/Py_Thing.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_THING_H
 #define RULESETS_PY_THING_H

--- a/rulesets/Py_Vector3D.cpp
+++ b/rulesets/Py_Vector3D.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_Vector3D.h"
 

--- a/rulesets/Py_Vector3D.h
+++ b/rulesets/Py_Vector3D.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_VECTOR_3D_H
 #define RULESETS_PY_VECTOR_3D_H

--- a/rulesets/Py_World.cpp
+++ b/rulesets/Py_World.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_World.h"
 #include "Py_WorldTime.h"

--- a/rulesets/Py_World.h
+++ b/rulesets/Py_World.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_WORLD_H
 #define RULESETS_PY_WORLD_H

--- a/rulesets/Py_WorldTime.cpp
+++ b/rulesets/Py_WorldTime.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Py_WorldTime.h"
 

--- a/rulesets/Py_WorldTime.h
+++ b/rulesets/Py_WorldTime.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PY_WORLD_TIME_H
 #define RULESETS_PY_WORLD_TIME_H

--- a/rulesets/PythonArithmeticFactory.cpp
+++ b/rulesets/PythonArithmeticFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonArithmeticFactory.h
+++ b/rulesets/PythonArithmeticFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_ARITHMETIC_FACTORY_H
 #define RULESETS_PYTHON_ARITHMETIC_FACTORY_H

--- a/rulesets/PythonArithmeticScript.cpp
+++ b/rulesets/PythonArithmeticScript.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonArithmeticScript.h
+++ b/rulesets/PythonArithmeticScript.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_ARITHMETIC_SCRIPT_H
 #define RULESETS_PYTHON_ARITHMETIC_SCRIPT_H

--- a/rulesets/PythonClass.cpp
+++ b/rulesets/PythonClass.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonClass.h
+++ b/rulesets/PythonClass.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_CLASS_H
 #define RULESETS_PYTHON_CLASS_H

--- a/rulesets/PythonContext.cpp
+++ b/rulesets/PythonContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 #include <Python-ast.h>

--- a/rulesets/PythonContext.h
+++ b/rulesets/PythonContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_CONTEXT_H
 #define RULESETS_PYTHON_CONTEXT_H

--- a/rulesets/PythonEntityScript.cpp
+++ b/rulesets/PythonEntityScript.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonEntityScript.h
+++ b/rulesets/PythonEntityScript.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_ENTITY_SCRIPT_H
 #define RULESETS_PYTHON_ENTITY_SCRIPT_H

--- a/rulesets/PythonScriptFactory.cpp
+++ b/rulesets/PythonScriptFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonScriptFactory.h
+++ b/rulesets/PythonScriptFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_SCRIPT_FACTORY_H
 #define RULESETS_PYTHON_SCRIPT_FACTORY_H

--- a/rulesets/PythonScriptFactory_impl.h
+++ b/rulesets/PythonScriptFactory_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_SCRIPT_FACTORY_IMPL_H
 #define RULESETS_PYTHON_SCRIPT_FACTORY_IMPL_H

--- a/rulesets/PythonWrapper.cpp
+++ b/rulesets/PythonWrapper.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include <Python.h>
 

--- a/rulesets/PythonWrapper.h
+++ b/rulesets/PythonWrapper.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_WRAPPER_H
 #define RULESETS_PYTHON_WRAPPER_H

--- a/rulesets/Python_API.cpp
+++ b/rulesets/Python_API.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Python.h"
 

--- a/rulesets/Python_API.h
+++ b/rulesets/Python_API.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_API_H
 #define RULESETS_PYTHON_API_H

--- a/rulesets/Python_Script_Utils.h
+++ b/rulesets/Python_Script_Utils.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_PYTHON_SCRIPT_UTILS_H
 #define RULESETS_PYTHON_SCRIPT_UTILS_H

--- a/rulesets/Script.cpp
+++ b/rulesets/Script.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Script.h"
 

--- a/rulesets/Script.h
+++ b/rulesets/Script.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_SCRIPT_H
 #define RULESETS_SCRIPT_H

--- a/rulesets/SolidProperty.cpp
+++ b/rulesets/SolidProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SolidProperty.h"
 

--- a/rulesets/SolidProperty.h
+++ b/rulesets/SolidProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_SOLID_PROPERTY_H
 #define RULESETS_SOLID_PROPERTY_H

--- a/rulesets/SpawnProperty.cpp
+++ b/rulesets/SpawnProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SpawnProperty.h"
 

--- a/rulesets/SpawnProperty.h
+++ b/rulesets/SpawnProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_SPAWN_PROPERTY_H
 #define RULESETS_SPAWN_PROPERTY_H

--- a/rulesets/Stackable.cpp
+++ b/rulesets/Stackable.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 // A stackable object, ie one which can represent multiple object of the
 // same type. Used for things like coins.

--- a/rulesets/Stackable.h
+++ b/rulesets/Stackable.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_STACKABLE_H
 #define RULESETS_STACKABLE_H

--- a/rulesets/Statistics.cpp
+++ b/rulesets/Statistics.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #error This file has been removed from the build.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rulesets/Statistics.h
+++ b/rulesets/Statistics.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #error This file has been removed from the build
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rulesets/StatisticsProperty.cpp
+++ b/rulesets/StatisticsProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "StatisticsProperty.h"
 

--- a/rulesets/StatisticsProperty.h
+++ b/rulesets/StatisticsProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_STATISTICS_PROPERTY_H
 #define RULESETS_STATISTICS_PROPERTY_H

--- a/rulesets/StatusProperty.cpp
+++ b/rulesets/StatusProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "StatusProperty.h"
 

--- a/rulesets/StatusProperty.h
+++ b/rulesets/StatusProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_STATUS_PROPERTY_H
 #define RULESETS_STATUS_PROPERTY_H

--- a/rulesets/SuspendedProperty.cpp
+++ b/rulesets/SuspendedProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SuspendedProperty.h"
 #include "common/BaseWorld.h"

--- a/rulesets/SuspendedProperty.h
+++ b/rulesets/SuspendedProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_SUSPENDEDPROPERTY_H_
 #define RULESETS_SUSPENDEDPROPERTY_H_

--- a/rulesets/Task.cpp
+++ b/rulesets/Task.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Task.h"
 

--- a/rulesets/Task.h
+++ b/rulesets/Task.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TASK_H
 #define RULESETS_TASK_H

--- a/rulesets/TasksProperty.cpp
+++ b/rulesets/TasksProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TasksProperty.h"
 

--- a/rulesets/TasksProperty.h
+++ b/rulesets/TasksProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TASKS_PROPERTY_H
 #define RULESETS_TASKS_PROPERTY_H

--- a/rulesets/TerrainEffectorProperty.cpp
+++ b/rulesets/TerrainEffectorProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TerrainEffectorProperty.h"
 

--- a/rulesets/TerrainEffectorProperty.h
+++ b/rulesets/TerrainEffectorProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TERRAIN_EFFECTOR_PROPERTY_H
 #define RULESETS_TERRAIN_EFFECTOR_PROPERTY_H

--- a/rulesets/TerrainModProperty.cpp
+++ b/rulesets/TerrainModProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TerrainModProperty.h"
 

--- a/rulesets/TerrainModProperty.h
+++ b/rulesets/TerrainModProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TERRAIN_MOD_PROPERTY_H
 #define RULESETS_TERRAIN_MOD_PROPERTY_H

--- a/rulesets/TerrainModTranslator.cpp
+++ b/rulesets/TerrainModTranslator.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TerrainModTranslator.h"
 

--- a/rulesets/TerrainModTranslator.h
+++ b/rulesets/TerrainModTranslator.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TERRAIN_MOD_TRANSLATOR_H
 #define RULESETS_TERRAIN_MOD_TRANSLATOR_H

--- a/rulesets/TerrainProperty.cpp
+++ b/rulesets/TerrainProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TerrainProperty.h"
 

--- a/rulesets/TerrainProperty.h
+++ b/rulesets/TerrainProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TERRAIN_PROPERTY_H
 #define RULESETS_TERRAIN_PROPERTY_H

--- a/rulesets/Thing.cpp
+++ b/rulesets/Thing.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Thing.h"
 

--- a/rulesets/Thing.h
+++ b/rulesets/Thing.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_THING_H
 #define RULESETS_THING_H

--- a/rulesets/TransientProperty.cpp
+++ b/rulesets/TransientProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TransientProperty.h"
 

--- a/rulesets/TransientProperty.h
+++ b/rulesets/TransientProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_TRANSIENT_PROPERTY_H
 #define RULESETS_TRANSIENT_PROPERTY_H

--- a/rulesets/VisibilityProperty.cpp
+++ b/rulesets/VisibilityProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "VisibilityProperty.h"
 

--- a/rulesets/VisibilityProperty.h
+++ b/rulesets/VisibilityProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_VISIBILITY_PROPERTY_H
 #define RULESETS_VISIBILITY_PROPERTY_H

--- a/rulesets/World.cpp
+++ b/rulesets/World.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "World.h"
 

--- a/rulesets/World.h
+++ b/rulesets/World.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef RULESETS_WORLD_H
 #define RULESETS_WORLD_H

--- a/rulesets/astronomy/Astronomy.h
+++ b/rulesets/astronomy/Astronomy.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ELEVATION_H
 #define ELEVATION_H

--- a/rulesets/astronomy/Body.h
+++ b/rulesets/astronomy/Body.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ASTRONOMY_BODY_H
 #define ASTRONOMY_BODY_H

--- a/rulesets/astronomy/Moon.h
+++ b/rulesets/astronomy/Moon.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ASTRONOMY_MOON_H
 #define ASTRONOMY_MOON_H

--- a/rulesets/astronomy/Planet.h
+++ b/rulesets/astronomy/Planet.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ASTRONOMY_PLANET_H
 #define ASTRONOMY_PLANET_H

--- a/rulesets/astronomy/Sun.h
+++ b/rulesets/astronomy/Sun.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ASTRONOMY_SUN_H
 #define ASTRONOMY_SUN_H

--- a/rulesets/astronomy/World.h
+++ b/rulesets/astronomy/World.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000 Alistair Riddoch
 
-// $Id$
 
 #ifndef ASTRONOMY_WORLD_H
 #define ASTRONOMY_WORLD_H

--- a/rulesets/skills/DumbSkill.cpp
+++ b/rulesets/skills/DumbSkill.cpp
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000,2001 Alistair Riddoch
 
-// $Id$
 
 #include "common/operations.h"
 

--- a/rulesets/skills/DumbSkill.h
+++ b/rulesets/skills/DumbSkill.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000,2001 Alistair Riddoch
 
-// $Id$
 
 #ifndef SKILLS_DUMB_SKILL_H
 #define SKILLS_DUMB_SKILL_H

--- a/rulesets/skills/Skill.h
+++ b/rulesets/skills/Skill.h
@@ -2,7 +2,6 @@
 // the GNU General Public License (See COPYING for details).
 // Copyright (C) 2000,2001 Alistair Riddoch
 
-// $Id$
 
 #ifndef SKILLS_SKILL_H
 #define SKILLS_SKILL_H

--- a/scripts/cyphesis-setup.sh
+++ b/scripts/cyphesis-setup.sh
@@ -15,7 +15,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-# $Id$
 
 # The main purpose of this script is to get round the issue of access to
 # to the database required by cyphesis.

--- a/server/Account.cpp
+++ b/server/Account.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Account.h"
 

--- a/server/Account.h
+++ b/server/Account.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ACCOUNT_H
 #define SERVER_ACCOUNT_H

--- a/server/Admin.cpp
+++ b/server/Admin.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Admin.h"
 

--- a/server/Admin.h
+++ b/server/Admin.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ADMIN_H
 #define SERVER_ADMIN_H

--- a/server/ArithmeticBuilder.cpp
+++ b/server/ArithmeticBuilder.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ArithmeticBuilder.h"
 

--- a/server/ArithmeticBuilder.h
+++ b/server/ArithmeticBuilder.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ARITHMETIC_BUILDER_H
 #define SERVER_ARITHMETIC_BUILDER_H

--- a/server/CommAdminClient.cpp
+++ b/server/CommAdminClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommAdminClient.h"
 

--- a/server/CommAdminClient.h
+++ b/server/CommAdminClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_ADMIN_CLIENT_H
 #define SERVER_COMM_ADMIN_CLIENT_H

--- a/server/CommClient.cpp
+++ b/server/CommClient.cpp
@@ -15,6 +15,5 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommClient_impl.h"

--- a/server/CommClient.h
+++ b/server/CommClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_CLIENT_H
 #define SERVER_COMM_CLIENT_H

--- a/server/CommClientFactory.cpp
+++ b/server/CommClientFactory.cpp
@@ -15,6 +15,5 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommClientFactory.h"

--- a/server/CommClientFactory.h
+++ b/server/CommClientFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_CLIENT_FACTORY_H
 #define SERVER_COMM_CLIENT_FACTORY_H

--- a/server/CommClientFactory_impl.h
+++ b/server/CommClientFactory_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommClientFactory.h"
 

--- a/server/CommClientKit.cpp
+++ b/server/CommClientKit.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommClientKit.h"
 

--- a/server/CommClientKit.h
+++ b/server/CommClientKit.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_CLIENT_KIT_H
 #define SERVER_COMM_CLIENT_KIT_H

--- a/server/CommClient_impl.h
+++ b/server/CommClient_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_CLIENT_IMPL_H
 #define SERVER_COMM_CLIENT_IMPL_H

--- a/server/CommHttpClient.cpp
+++ b/server/CommHttpClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommHttpClient.h"
 #include "CommServer.h"

--- a/server/CommHttpClient.h
+++ b/server/CommHttpClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_HTTP_CLIENT_H
 #define SERVER_COMM_HTTP_CLIENT_H

--- a/server/CommHttpClientFactory.cpp
+++ b/server/CommHttpClientFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommHttpClientFactory.h"
 

--- a/server/CommHttpClientFactory.h
+++ b/server/CommHttpClientFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_HTTP_CLIENT_FACTORY_H
 #define SERVER_COMM_HTTP_CLIENT_FACTORY_H

--- a/server/CommMDNSPublisher.cpp
+++ b/server/CommMDNSPublisher.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommMDNSPublisher.h
+++ b/server/CommMDNSPublisher.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_MDNS_PUBLISHER_H
 #define SERVER_COMM_MDNS_PUBLISHER_H

--- a/server/CommMaster.cpp
+++ b/server/CommMaster.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommMaster.h"
 

--- a/server/CommMaster.h
+++ b/server/CommMaster.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_MASTER_H
 #define SERVER_COMM_MASTER_H

--- a/server/CommMetaClient.cpp
+++ b/server/CommMetaClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommMetaClient.h
+++ b/server/CommMetaClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_META_CLIENT_H
 #define SERVER_COMM_META_CLIENT_H

--- a/server/CommPSQLSocket.cpp
+++ b/server/CommPSQLSocket.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommPSQLSocket.h"
 

--- a/server/CommPSQLSocket.h
+++ b/server/CommPSQLSocket.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_PSQL_SOCKET_H
 #define SERVER_COMM_PSQL_SOCKET_H

--- a/server/CommPeer.cpp
+++ b/server/CommPeer.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommPeer.h"
 

--- a/server/CommPeer.h
+++ b/server/CommPeer.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_PEER_H
 #define SERVER_COMM_PEER_H

--- a/server/CommPythonClient.cpp
+++ b/server/CommPythonClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommPythonClient.h"
 #include "CommServer.h"

--- a/server/CommPythonClient.h
+++ b/server/CommPythonClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_PYTHON_CLIENT_H
 #define SERVER_COMM_PYTHON_CLIENT_H

--- a/server/CommPythonClientFactory.cpp
+++ b/server/CommPythonClientFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommPythonClientFactory.h"
 

--- a/server/CommPythonClientFactory.h
+++ b/server/CommPythonClientFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_PYTHON_CLIENT_FACTORY_H
 #define SERVER_COMM_PYTHON_CLIENT_FACTORY_H

--- a/server/CommServer.cpp
+++ b/server/CommServer.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommServer.h
+++ b/server/CommServer.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_SERVER_H
 #define SERVER_COMM_SERVER_H

--- a/server/CommStreamClient.cpp
+++ b/server/CommStreamClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommStreamClient_impl.h"
 

--- a/server/CommStreamClient.h
+++ b/server/CommStreamClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_STREAM_CLIENT_H
 #define SERVER_COMM_STREAM_CLIENT_H

--- a/server/CommStreamClient_impl.h
+++ b/server/CommStreamClient_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_STREAM_CLIENT_IMPL_H
 #define SERVER_COMM_STREAM_CLIENT_IMPL_H

--- a/server/CommStreamListener.cpp
+++ b/server/CommStreamListener.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommStreamListener.h
+++ b/server/CommStreamListener.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_STREAM_LISTENER_H
 #define SERVER_COMM_STREAM_LISTENER_H

--- a/server/CommStreamListener_impl.h
+++ b/server/CommStreamListener_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_STREAM_LISTENER_IMPL_H
 #define SERVER_COMM_STREAM_LISTENER_IMPL_H

--- a/server/CommTCPListener.cpp
+++ b/server/CommTCPListener.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommTCPListener.h
+++ b/server/CommTCPListener.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_TCP_LISTENER_H
 #define SERVER_COMM_TCP_LISTENER_H

--- a/server/CommUnixListener.cpp
+++ b/server/CommUnixListener.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/CommUnixListener.h
+++ b/server/CommUnixListener.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_UNIX_LISTENER_H
 #define SERVER_COMM_UNIX_LISTENER_H

--- a/server/CommUserClient.cpp
+++ b/server/CommUserClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommUserClient.h"
 

--- a/server/CommUserClient.h
+++ b/server/CommUserClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_COMM_USER_CLIENT_H
 #define SERVER_COMM_USER_CLIENT_H

--- a/server/ConnectableRouter.cpp
+++ b/server/ConnectableRouter.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ConnectableRouter.h"
 

--- a/server/ConnectableRouter.h
+++ b/server/ConnectableRouter.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_CONNECTABLE_ROUTER_H
 #define SERVER_CONNECTABLE_ROUTER_H

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Connection.h"
 

--- a/server/Connection.h
+++ b/server/Connection.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_CONNECTION_H
 #define SERVER_CONNECTION_H

--- a/server/Connection_methods.h
+++ b/server/Connection_methods.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_CONNECTION_METHODS_H
 #define SERVER_CONNECTION_METHODS_H

--- a/server/CorePropertyManager.cpp
+++ b/server/CorePropertyManager.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CorePropertyManager.h"
 

--- a/server/CorePropertyManager.h
+++ b/server/CorePropertyManager.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_CORE_PROPERTY_MANAGER_H
 #define SERVER_CORE_PROPERTY_MANAGER_H

--- a/server/EntityBuilder.cpp
+++ b/server/EntityBuilder.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityBuilder.h"
 

--- a/server/EntityBuilder.h
+++ b/server/EntityBuilder.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ENTITY_BUILDER_H
 #define SERVER_ENTITY_BUILDER_H

--- a/server/EntityFactory.cpp
+++ b/server/EntityFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityFactory_impl.h"
 

--- a/server/EntityFactory.h
+++ b/server/EntityFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ENTITY_FACTORY_H
 #define SERVER_ENTITY_FACTORY_H

--- a/server/EntityFactory_impl.h
+++ b/server/EntityFactory_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ENTITY_FACTORY_IMPL_H
 #define SERVER_ENTITY_FACTORY_IMPL_H

--- a/server/EntityRuleHandler.cpp
+++ b/server/EntityRuleHandler.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "EntityRuleHandler.h"
 

--- a/server/EntityRuleHandler.h
+++ b/server/EntityRuleHandler.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_ENTITY_RULE_HANDLER_H
 #define SERVER_ENTITY_RULE_HANDLER_H

--- a/server/HttpCache.cpp
+++ b/server/HttpCache.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "HttpCache.h"
 

--- a/server/HttpCache.h
+++ b/server/HttpCache.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_HTTP_CACHE_H
 #define SERVER_HTTP_CACHE_H

--- a/server/Idle.cpp
+++ b/server/Idle.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Idle.h"
 

--- a/server/Idle.h
+++ b/server/Idle.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_IDLE_H
 #define SERVER_IDLE_H

--- a/server/IdleConnector.cpp
+++ b/server/IdleConnector.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "IdleConnector.h"
 

--- a/server/IdleConnector.h
+++ b/server/IdleConnector.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_IDLE_CONNECTOR_H
 #define SERVER_IDLE_CONNECTOR_H

--- a/server/IdlePSQLConnector.cpp
+++ b/server/IdlePSQLConnector.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "IdlePSQLConnector.h"
 

--- a/server/IdlePSQLConnector.h
+++ b/server/IdlePSQLConnector.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_IDLE_PSQL_CONNECTOR_H
 #define SERVER_IDLE_PSQL_CONNECTOR_H

--- a/server/Juncture.cpp
+++ b/server/Juncture.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Juncture.h"
 

--- a/server/Juncture.h
+++ b/server/Juncture.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_JUNCTURE_H
 #define SERVER_JUNCTURE_H

--- a/server/Lobby.cpp
+++ b/server/Lobby.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Lobby.h"
 

--- a/server/Lobby.h
+++ b/server/Lobby.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_LOBBY_H
 #define SERVER_LOBBY_H

--- a/server/Master.cpp
+++ b/server/Master.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Master.h"
 

--- a/server/Master.h
+++ b/server/Master.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_MASTER_H
 #define SERVER_MASTER_H

--- a/server/OpRuleHandler.cpp
+++ b/server/OpRuleHandler.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "OpRuleHandler.h"
 

--- a/server/OpRuleHandler.h
+++ b/server/OpRuleHandler.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_OP_RULE_HANDLER_H
 #define SERVER_OP_RULE_HANDLER_H

--- a/server/Peer.cpp
+++ b/server/Peer.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Peer.h"
 

--- a/server/Peer.h
+++ b/server/Peer.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_PEER_H
 #define SERVER_PEER_H

--- a/server/Persistence.cpp
+++ b/server/Persistence.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Persistence.h"
 

--- a/server/Persistence.h
+++ b/server/Persistence.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_PERSISTENCE_H
 #define SERVER_PERSISTENCE_H

--- a/server/Player.cpp
+++ b/server/Player.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Player.h"
 

--- a/server/Player.h
+++ b/server/Player.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_PLAYER_H
 #define SERVER_PLAYER_H

--- a/server/PropertyRuleHandler.cpp
+++ b/server/PropertyRuleHandler.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "PropertyRuleHandler.h"
 

--- a/server/PropertyRuleHandler.h
+++ b/server/PropertyRuleHandler.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_PROPERTY_RULE_HANDLER_H
 #define SERVER_PROPERTY_RULE_HANDLER_H

--- a/server/RuleHandler.cpp
+++ b/server/RuleHandler.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "RuleHandler.h"
 

--- a/server/RuleHandler.h
+++ b/server/RuleHandler.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_RULE_HANDLER_H
 #define SERVER_RULE_HANDLER_H

--- a/server/Ruleset.cpp
+++ b/server/Ruleset.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/Ruleset.h
+++ b/server/Ruleset.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_RULESET_H
 #define SERVER_RULESET_H

--- a/server/ServerAccount.cpp
+++ b/server/ServerAccount.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ServerAccount.h"
 

--- a/server/ServerAccount.h
+++ b/server/ServerAccount.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SERVER_ACCOUNT_H
 #define SERVER_SERVER_ACCOUNT_H

--- a/server/ServerRouting.cpp
+++ b/server/ServerRouting.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ServerRouting.h"
 

--- a/server/ServerRouting.h
+++ b/server/ServerRouting.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SERVER_ROUTING_H
 #define SERVER_SERVER_ROUTING_H

--- a/server/SlaveClientConnection.cpp
+++ b/server/SlaveClientConnection.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SlaveClientConnection.h"
 

--- a/server/SlaveClientConnection.h
+++ b/server/SlaveClientConnection.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SLAVE_CLIENT_CONNECTION_H
 #define SERVER_SLAVE_CLIENT_CONNECTION_H

--- a/server/Spawn.cpp
+++ b/server/Spawn.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Spawn.h"
 

--- a/server/Spawn.h
+++ b/server/Spawn.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SPAWN_H
 #define SERVER_SPAWN_H

--- a/server/SpawnEntity.cpp
+++ b/server/SpawnEntity.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "SpawnEntity.h"
 

--- a/server/SpawnEntity.h
+++ b/server/SpawnEntity.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SPAWN_ENTITY_H
 #define SERVER_SPAWN_ENTITY_H

--- a/server/StorageManager.cpp
+++ b/server/StorageManager.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "StorageManager.h"
 

--- a/server/StorageManager.h
+++ b/server/StorageManager.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_STORAGE_MANAGER_H
 #define SERVER_STORAGE_MANAGER_H

--- a/server/SystemAccount.cpp
+++ b/server/SystemAccount.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "server/SystemAccount.h"
 

--- a/server/SystemAccount.h
+++ b/server/SystemAccount.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SYSTEM_ACCOUNT_H
 #define SERVER_SYSTEM_ACCOUNT_H

--- a/server/TCPListenFactory.cpp
+++ b/server/TCPListenFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TCPListenFactory.h"
 

--- a/server/TCPListenFactory.h
+++ b/server/TCPListenFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_TCP_LISTEN_FACTORY_H
 #define SERVER_TCP_LISTEN_FACTORY_H

--- a/server/TaskFactory.cpp
+++ b/server/TaskFactory.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "server/TaskFactory.h"
 

--- a/server/TaskFactory.h
+++ b/server/TaskFactory.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_TASK_FACTORY_H
 #define SERVER_TASK_FACTORY_H

--- a/server/TaskRuleHandler.cpp
+++ b/server/TaskRuleHandler.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TaskRuleHandler.h"
 

--- a/server/TaskRuleHandler.h
+++ b/server/TaskRuleHandler.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_TASK_RULE_HANDLER_H
 #define SERVER_TASK_RULE_HANDLER_H

--- a/server/TeleportProperty.cpp
+++ b/server/TeleportProperty.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "server/TeleportProperty.h"
 

--- a/server/TeleportProperty.h
+++ b/server/TeleportProperty.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_TELEPORT_PROPERTY_H
 #define SERVER_TELEPORT_PROPERTY_H

--- a/server/TrustedConnection.cpp
+++ b/server/TrustedConnection.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "TrustedConnection.h"
 

--- a/server/TrustedConnection.h
+++ b/server/TrustedConnection.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_TRUSTED_CONNECTION_H
 #define SERVER_TRUSTED_CONNECTION_H

--- a/server/UpdateTester.cpp
+++ b/server/UpdateTester.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "UpdateTester.h"
 

--- a/server/UpdateTester.h
+++ b/server/UpdateTester.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_UPDATE_TESTER_H
 #define SERVER_UPDATE_TESTER_H

--- a/server/WorldRouter.cpp
+++ b/server/WorldRouter.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "WorldRouter.h"
 

--- a/server/WorldRouter.h
+++ b/server/WorldRouter.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_WORLD_ROUTER_H
 #define SERVER_WORLD_ROUTER_H

--- a/server/frontend.cpp
+++ b/server/frontend.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/server/server.h
+++ b/server/server.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef SERVER_SERVER_H
 #define SERVER_SERVER_H

--- a/server/slave.cpp
+++ b/server/slave.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "CommServer.h"
 #include "CommMaster.h"

--- a/tests/AccountConnectionCharacterintegration.cpp
+++ b/tests/AccountConnectionCharacterintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AccountConnectionintegration.cpp
+++ b/tests/AccountConnectionintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AccountServerLobbyintegration.cpp
+++ b/tests/AccountServerLobbyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Accountintegration.cpp
+++ b/tests/Accountintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Accounttest.cpp
+++ b/tests/Accounttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Addtest.cpp
+++ b/tests/Addtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AdminClienttest.cpp
+++ b/tests/AdminClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Admintest.cpp
+++ b/tests/Admintest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AllPropertytest.cpp
+++ b/tests/AllPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AreaPropertyintegration.cpp
+++ b/tests/AreaPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AreaPropertytest.cpp
+++ b/tests/AreaPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Areatest.cpp
+++ b/tests/Areatest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ArithmeticBuildertest.cpp
+++ b/tests/ArithmeticBuildertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ArithmeticFactorytest.cpp
+++ b/tests/ArithmeticFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ArithmeticScripttest.cpp
+++ b/tests/ArithmeticScripttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AtlasFileLoadertest.cpp
+++ b/tests/AtlasFileLoadertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AtlasPropertiestest.cpp
+++ b/tests/AtlasPropertiestest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/AtlasStreamClienttest.cpp
+++ b/tests/AtlasStreamClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Attacktest.cpp
+++ b/tests/Attacktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BBoxPropertytest.cpp
+++ b/tests/BBoxPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BBoxtest.cpp
+++ b/tests/BBoxtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BaseClienttest.cpp
+++ b/tests/BaseClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BaseMindMapEntityintegration.cpp
+++ b/tests/BaseMindMapEntityintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BaseMindtest.cpp
+++ b/tests/BaseMindtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BaseWorldtest.cpp
+++ b/tests/BaseWorldtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BiomassPropertyintegration.cpp
+++ b/tests/BiomassPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BiomassPropertytest.cpp
+++ b/tests/BiomassPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/BulletDomainintegration.cpp
+++ b/tests/BulletDomainintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tests/BulletDomaintest.cpp
+++ b/tests/BulletDomaintest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "rulesets/BulletDomain.h"
 

--- a/tests/BurnSpeedPropertytest.cpp
+++ b/tests/BurnSpeedPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Burntest.cpp
+++ b/tests/Burntest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CalendarPropertytest.cpp
+++ b/tests/CalendarPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Charactertest.cpp
+++ b/tests/Charactertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Choptest.cpp
+++ b/tests/Choptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ClientConnectionintegration.cpp
+++ b/tests/ClientConnectionintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ClientConnectiontest.cpp
+++ b/tests/ClientConnectiontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ClientPropertyManagertest.cpp
+++ b/tests/ClientPropertyManagertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ClientTasktest.cpp
+++ b/tests/ClientTasktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Collisiontest.cpp
+++ b/tests/Collisiontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommClientFactorytest.cpp
+++ b/tests/CommClientFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommClientKittest.cpp
+++ b/tests/CommClientKittest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommClient_null_stream.cpp
+++ b/tests/CommClient_null_stream.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "null_stream.h"
 #include "CommClient_stub_impl.h"

--- a/tests/CommClient_stub_impl.h
+++ b/tests/CommClient_stub_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "server/CommClient.h"
 

--- a/tests/CommClienttest.cpp
+++ b/tests/CommClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommHttpClientFactorytest.cpp
+++ b/tests/CommHttpClientFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommHttpClienttest.cpp
+++ b/tests/CommHttpClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommMDNSPublishertest.cpp
+++ b/tests/CommMDNSPublishertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommPSQLSockettest.cpp
+++ b/tests/CommPSQLSockettest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommPeertest.cpp
+++ b/tests/CommPeertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommPythonClientFactorytest.cpp
+++ b/tests/CommPythonClientFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommServertest.cpp
+++ b/tests/CommServertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommSockettest.cpp
+++ b/tests/CommSockettest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommStreamClient_null_stream.cpp
+++ b/tests/CommStreamClient_null_stream.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "null_stream.h"
 #include "CommStreamClient_stub_impl.h"

--- a/tests/CommStreamClient_stub_impl.h
+++ b/tests/CommStreamClient_stub_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "server/CommStreamClient.h"
 

--- a/tests/CommStreamClienttest.cpp
+++ b/tests/CommStreamClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CommStreamListener_stub_impl.h
+++ b/tests/CommStreamListener_stub_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_COMM_STREAM_LISTENER_STUB_IMPL_H
 #define TESTS_COMM_STREAM_LISTENER_STUB_IMPL_H

--- a/tests/CommStreamListenertest.cpp
+++ b/tests/CommStreamListenertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ConnectableRoutertest.cpp
+++ b/tests/ConnectableRoutertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ConnectionCharacterintegration.cpp
+++ b/tests/ConnectionCharacterintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ConnectionCreatorintegration.cpp
+++ b/tests/ConnectionCreatorintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ConnectionShakerintegration.cpp
+++ b/tests/ConnectionShakerintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Connectiontest.cpp
+++ b/tests/Connectiontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Connecttest.cpp
+++ b/tests/Connecttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Containertest.cpp
+++ b/tests/Containertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/CorePropertyManagertest.cpp
+++ b/tests/CorePropertyManagertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Coursetest.cpp
+++ b/tests/Coursetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Creatortest.cpp
+++ b/tests/Creatortest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Cuttest.cpp
+++ b/tests/Cuttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Databasetest.cpp
+++ b/tests/Databasetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/DateTimetest.cpp
+++ b/tests/DateTimetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/DecaysPropertyintegration.cpp
+++ b/tests/DecaysPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/DecaysPropertytest.cpp
+++ b/tests/DecaysPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Delvetest.cpp
+++ b/tests/Delvetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Digtest.cpp
+++ b/tests/Digtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Domaintest.cpp
+++ b/tests/Domaintest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Droptest.cpp
+++ b/tests/Droptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Eattest.cpp
+++ b/tests/Eattest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityBuildertest.cpp
+++ b/tests/EntityBuildertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityExerciser.cpp
+++ b/tests/EntityExerciser.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityExerciser.h
+++ b/tests/EntityExerciser.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_ENTITY_EXERCISER_H
 #define TESTS_ENTITY_EXERCISER_H

--- a/tests/EntityFactoryTypeNodeintegration.cpp
+++ b/tests/EntityFactoryTypeNodeintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityFactorytest.cpp
+++ b/tests/EntityFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityKittest.cpp
+++ b/tests/EntityKittest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityPropertiestest.cpp
+++ b/tests/EntityPropertiestest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityPropertytest.cpp
+++ b/tests/EntityPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityReftest.cpp
+++ b/tests/EntityReftest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/EntityRuleHandlertest.cpp
+++ b/tests/EntityRuleHandlertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Entitytest.cpp
+++ b/tests/Entitytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ExternalMindtest.cpp
+++ b/tests/ExternalMindtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ExternalPropertytest.cpp
+++ b/tests/ExternalPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Flushertest.cpp
+++ b/tests/Flushertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Foodtest.cpp
+++ b/tests/Foodtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/FormattedXMLWritertest.cpp
+++ b/tests/FormattedXMLWritertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/HttpCachetest.cpp
+++ b/tests/HttpCachetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/IGEntityExerciser.cpp
+++ b/tests/IGEntityExerciser.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/IGEntityExerciser.h
+++ b/tests/IGEntityExerciser.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_IG_ENTITY_EXERCISER_H
 #define TESTS_IG_ENTITY_EXERCISER_H

--- a/tests/IdleConnectortest.cpp
+++ b/tests/IdleConnectortest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Idletest.cpp
+++ b/tests/Idletest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Inheritancetest.cpp
+++ b/tests/Inheritancetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/InternalPropertiestest.cpp
+++ b/tests/InternalPropertiestest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Juncturetest.cpp
+++ b/tests/Juncturetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/LinePropertytest.cpp
+++ b/tests/LinePropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Linetest.cpp
+++ b/tests/Linetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Linktest.cpp
+++ b/tests/Linktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Lobbytest.cpp
+++ b/tests/Lobbytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/LocatedEntitytest.cpp
+++ b/tests/LocatedEntitytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Locationtest.cpp
+++ b/tests/Locationtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Mastertest.cpp
+++ b/tests/Mastertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MemEntitytest.cpp
+++ b/tests/MemEntitytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MemMaptest.cpp
+++ b/tests/MemMaptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MindFactorytest.cpp
+++ b/tests/MindFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MindPropertyintegration.cpp
+++ b/tests/MindPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MindPropertytest.cpp
+++ b/tests/MindPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Monitorstest.cpp
+++ b/tests/Monitorstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Monitortest.cpp
+++ b/tests/Monitortest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Motiontest.cpp
+++ b/tests/Motiontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Movementtest.cpp
+++ b/tests/Movementtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Mowtest.cpp
+++ b/tests/Mowtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/MultiLineListFormattertest.cpp
+++ b/tests/MultiLineListFormattertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Nourishtest.cpp
+++ b/tests/Nourishtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/OpRuleHandlertest.cpp
+++ b/tests/OpRuleHandlertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/OperationExerciser.cpp
+++ b/tests/OperationExerciser.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/OperationExerciser.h
+++ b/tests/OperationExerciser.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_OPERATION_EXERCISER_H
 #define TESTS_OPERATION_EXERCISER_H

--- a/tests/OperationMonitortest.cpp
+++ b/tests/OperationMonitortest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/OperationRoutertest.cpp
+++ b/tests/OperationRoutertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/OutfitPropertytest.cpp
+++ b/tests/OutfitPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Pedestriantest.cpp
+++ b/tests/Pedestriantest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Peertest.cpp
+++ b/tests/Peertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PendingTeleporttest.cpp
+++ b/tests/PendingTeleporttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Persistencetest.cpp
+++ b/tests/Persistencetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Pickuptest.cpp
+++ b/tests/Pickuptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Planttest.cpp
+++ b/tests/Planttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Playertest.cpp
+++ b/tests/Playertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyCoverage.cpp
+++ b/tests/PropertyCoverage.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyCoverage.h
+++ b/tests/PropertyCoverage.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_PROPERTY_COVERAGE_H
 #define TESTS_PROPERTY_COVERAGE_H

--- a/tests/PropertyEntityintegration.cpp
+++ b/tests/PropertyEntityintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyExerciser.cpp
+++ b/tests/PropertyExerciser.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyExerciser.h
+++ b/tests/PropertyExerciser.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_PROPERTY_EXERCISER_H
 #define TESTS_PROPERTY_EXERCISER_H

--- a/tests/PropertyFactorytest.cpp
+++ b/tests/PropertyFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyFlagtest.cpp
+++ b/tests/PropertyFlagtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyManagertest.cpp
+++ b/tests/PropertyManagertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PropertyRuleHandlertest.cpp
+++ b/tests/PropertyRuleHandlertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Property_stub_impl.h
+++ b/tests/Property_stub_impl.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_PROPERTY_STUB_IMPL_H
 #define TESTS_PROPERTY_STUB_IMPL_H

--- a/tests/Propertytest.cpp
+++ b/tests/Propertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_BBoxtest.cpp
+++ b/tests/Py_BBoxtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_CreatorClienttest.cpp
+++ b/tests/Py_CreatorClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Locationtest.cpp
+++ b/tests/Py_Locationtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Maptest.cpp
+++ b/tests/Py_Maptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Messagetest.cpp
+++ b/tests/Py_Messagetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_ObserverClienttest.cpp
+++ b/tests/Py_ObserverClienttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Operationtest.cpp
+++ b/tests/Py_Operationtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Oplisttest.cpp
+++ b/tests/Py_Oplisttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Point3Dtest.cpp
+++ b/tests/Py_Point3Dtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Propertytest.cpp
+++ b/tests/Py_Propertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Quaterniontest.cpp
+++ b/tests/Py_Quaterniontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_RootEntitytest.cpp
+++ b/tests/Py_RootEntitytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Shapetest.cpp
+++ b/tests/Py_Shapetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Tasktest.cpp
+++ b/tests/Py_Tasktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_TerrainModPropertytest.cpp
+++ b/tests/Py_TerrainModPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_TerrainPropertytest.cpp
+++ b/tests/Py_TerrainPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Thingtest.cpp
+++ b/tests/Py_Thingtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Vector3Dtest.cpp
+++ b/tests/Py_Vector3Dtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_WorldTimetest.cpp
+++ b/tests/Py_WorldTimetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Py_Worldtest.cpp
+++ b/tests/Py_Worldtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonArithmeticFactorytest.cpp
+++ b/tests/PythonArithmeticFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonArithmeticScripttest.cpp
+++ b/tests/PythonArithmeticScripttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonClasstest.cpp
+++ b/tests/PythonClasstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonContexttest.cpp
+++ b/tests/PythonContexttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonEntityScripttest.cpp
+++ b/tests/PythonEntityScripttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/PythonWrappertest.cpp
+++ b/tests/PythonWrappertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Python_APItest.cpp
+++ b/tests/Python_APItest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Quaterniontest.cpp
+++ b/tests/Quaterniontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Routertest.cpp
+++ b/tests/Routertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/RuleHandlertest.cpp
+++ b/tests/RuleHandlertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Rulesetintegration.cpp
+++ b/tests/Rulesetintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Rulesettest.cpp
+++ b/tests/Rulesettest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ScriptKittest.cpp
+++ b/tests/ScriptKittest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Scripttest.cpp
+++ b/tests/Scripttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ServerAccounttest.cpp
+++ b/tests/ServerAccounttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ServerRoutingtest.cpp
+++ b/tests/ServerRoutingtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Setuptest.cpp
+++ b/tests/Setuptest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Shapetest.cpp
+++ b/tests/Shapetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Sink.h
+++ b/tests/Sink.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_SINK_H
 #define TESTS_SINK_H

--- a/tests/SolidPropertytest.cpp
+++ b/tests/SolidPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/SpawnEntitytest.cpp
+++ b/tests/SpawnEntitytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/SpawnPropertytest.cpp
+++ b/tests/SpawnPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Spawntest.cpp
+++ b/tests/Spawntest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Stackabletest.cpp
+++ b/tests/Stackabletest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/StatisticsPropertyintegration.cpp
+++ b/tests/StatisticsPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/StatisticsPropertytest.cpp
+++ b/tests/StatisticsPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/StatusPropertytest.cpp
+++ b/tests/StatusPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/StorageManagertest.cpp
+++ b/tests/StorageManagertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Storagetest.cpp
+++ b/tests/Storagetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Structuretest.cpp
+++ b/tests/Structuretest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/SystemAccounttest.cpp
+++ b/tests/SystemAccounttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/SystemTimetest.cpp
+++ b/tests/SystemTimetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TCPListenFactorytest.cpp
+++ b/tests/TCPListenFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TaskFactorytest.cpp
+++ b/tests/TaskFactorytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TaskKittest.cpp
+++ b/tests/TaskKittest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TaskRuleHandlertest.cpp
+++ b/tests/TaskRuleHandlertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TaskScripttest.cpp
+++ b/tests/TaskScripttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TasksPropertytest.cpp
+++ b/tests/TasksPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Tasktest.cpp
+++ b/tests/Tasktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TeleportAuthenticatortest.cpp
+++ b/tests/TeleportAuthenticatortest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TeleportStatetest.cpp
+++ b/tests/TeleportStatetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainContexttest.cpp
+++ b/tests/TerrainContexttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainEffectorPropertytest.cpp
+++ b/tests/TerrainEffectorPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainModPropertyintegration.cpp
+++ b/tests/TerrainModPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainModPropertytest.cpp
+++ b/tests/TerrainModPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainModtest.cpp
+++ b/tests/TerrainModtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainPropertyintegration.cpp
+++ b/tests/TerrainPropertyintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TerrainPropertytest.cpp
+++ b/tests/TerrainPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TestBase.h
+++ b/tests/TestBase.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_TEST_BASE_H
 #define TESTS_TEST_BASE_H

--- a/tests/TestBasetest.cpp
+++ b/tests/TestBasetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TestPropertyManager.cpp
+++ b/tests/TestPropertyManager.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TestPropertyManager.h
+++ b/tests/TestPropertyManager.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_TEST_PROPERTY_MANAGER_H
 #define TESTS_TEST_PROPERTY_MANAGER_H

--- a/tests/TestWorld.h
+++ b/tests/TestWorld.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_TEST_WORLD_H
 #define TESTS_TEST_WORLD_H

--- a/tests/Thingtest.cpp
+++ b/tests/Thingtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/ThingupdatePropertiestest.cpp
+++ b/tests/ThingupdatePropertiestest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Ticktest.cpp
+++ b/tests/Ticktest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TransientPropertytest.cpp
+++ b/tests/TransientPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TrustedConnectionCreatorintegration.cpp
+++ b/tests/TrustedConnectionCreatorintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TrustedConnectiontest.cpp
+++ b/tests/TrustedConnectiontest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/TypeNodetest.cpp
+++ b/tests/TypeNodetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Unseentest.cpp
+++ b/tests/Unseentest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/UpdateTestertest.cpp
+++ b/tests/UpdateTestertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Updatetest.cpp
+++ b/tests/Updatetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Variabletest.cpp
+++ b/tests/Variabletest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Vector3Dtest.cpp
+++ b/tests/Vector3Dtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/VisibilityPropertytest.cpp
+++ b/tests/VisibilityPropertytest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldDumpertest.cpp
+++ b/tests/WorldDumpertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldLoaderintegration.cpp
+++ b/tests/WorldLoaderintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldLoadertest.cpp
+++ b/tests/WorldLoadertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldRouterintegration.cpp
+++ b/tests/WorldRouterintegration.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldRoutertest.cpp
+++ b/tests/WorldRoutertest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/WorldTimetest.cpp
+++ b/tests/WorldTimetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/Worldtest.cpp
+++ b/tests/Worldtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/allOperations.h
+++ b/tests/allOperations.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_ALL_OPERATIONS_H
 #define TESTS_ALL_OPERATIONS_H

--- a/tests/atlas_helperstest.cpp
+++ b/tests/atlas_helperstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/buildidtest.cpp
+++ b/tests/buildidtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/client_sockettest.cpp
+++ b/tests/client_sockettest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/composetest.cpp
+++ b/tests/composetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/consttest.cpp
+++ b/tests/consttest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/customtest.cpp
+++ b/tests/customtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/debugtest.cpp
+++ b/tests/debugtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/distancetest.cpp
+++ b/tests/distancetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/emergencetest.cpp
+++ b/tests/emergencetest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/globalstest.cpp
+++ b/tests/globalstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/idtest.cpp
+++ b/tests/idtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/logtest.cpp
+++ b/tests/logtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/newidtest.cpp
+++ b/tests/newidtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/null_stream.h
+++ b/tests/null_stream.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_NULL_STREAM_H
 #define TESTS_NULL_STREAM_H

--- a/tests/operationstest.cpp
+++ b/tests/operationstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/python_class.cpp
+++ b/tests/python_class.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/python_testers.cpp
+++ b/tests/python_testers.cpp
@@ -20,7 +20,6 @@
 // is a derivative work. The derivative is distributed under the GPL as
 // permitted by the license used by Python Software Foundation.
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/python_testers.h
+++ b/tests/python_testers.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TESTS_PYTHON_TESTERS_H
 #define TESTS_PYTHON_TESTERS_H

--- a/tests/randomtest.cpp
+++ b/tests/randomtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/serialnotest.cpp
+++ b/tests/serialnotest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/system_nettest.cpp
+++ b/tests/system_nettest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/system_uidtest.cpp
+++ b/tests/system_uidtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/systemtest.cpp
+++ b/tests/systemtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/transformtest.cpp
+++ b/tests/transformtest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/type_utilstest.cpp
+++ b/tests/type_utilstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tests/utilstest.cpp
+++ b/tests/utilstest.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef NDEBUG
 #undef NDEBUG

--- a/tools/AccountContext.cpp
+++ b/tools/AccountContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "AccountContext.h"
 

--- a/tools/AccountContext.h
+++ b/tools/AccountContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_ACCOUNT_CONTEXT_H
 #define TOOLS_ACCOUNT_CONTEXT_H

--- a/tools/AdminClient.cpp
+++ b/tools/AdminClient.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "AdminClient.h"
 

--- a/tools/AdminClient.h
+++ b/tools/AdminClient.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_ADMIN_CLIENT_H
 #define TOOLS_ADMIN_CLIENT_H

--- a/tools/AvatarContext.cpp
+++ b/tools/AvatarContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "AvatarContext.h"
 

--- a/tools/AvatarContext.h
+++ b/tools/AvatarContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_AVATAR_CONTEXT_H
 #define TOOLS_AVATAR_CONTEXT_H

--- a/tools/ConnectionContext.cpp
+++ b/tools/ConnectionContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ConnectionContext.h"
 

--- a/tools/ConnectionContext.h
+++ b/tools/ConnectionContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_CONNECTION_CONTEXT_H
 #define TOOLS_CONNECTION_CONTEXT_H

--- a/tools/Flusher.cpp
+++ b/tools/Flusher.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "Flusher.h"
 

--- a/tools/Flusher.h
+++ b/tools/Flusher.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_FLUSHER_H
 #define TOOLS_FLUSHER_H

--- a/tools/IdContext.cpp
+++ b/tools/IdContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "IdContext.h"
 

--- a/tools/IdContext.h
+++ b/tools/IdContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_ID_CONTEXT_H
 #define TOOLS_ID_CONTEXT_H

--- a/tools/Interactive.cpp
+++ b/tools/Interactive.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tools/Interactive.h
+++ b/tools/Interactive.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_INTERACTIVE_H
 #define TOOLS_INTERACTIVE_H

--- a/tools/JunctureContext.cpp
+++ b/tools/JunctureContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "JunctureContext.h"
 

--- a/tools/JunctureContext.h
+++ b/tools/JunctureContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_JUNCTURE_CONTEXT_H
 #define TOOLS_JUNCTURE_CONTEXT_H

--- a/tools/MultiLineListFormatter.cpp
+++ b/tools/MultiLineListFormatter.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "MultiLineListFormatter.h"
 

--- a/tools/MultiLineListFormatter.h
+++ b/tools/MultiLineListFormatter.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_MULTI_LINE_LIST_FORMATTER_H
 #define TOOLS_MULTI_LINE_LIST_FORMATTER_H

--- a/tools/ObjectContext.cpp
+++ b/tools/ObjectContext.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "ObjectContext.h"
 

--- a/tools/ObjectContext.h
+++ b/tools/ObjectContext.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_OBJECT_CONTEXT_H
 #define TOOLS_OBJECT_CONTEXT_H

--- a/tools/OperationMonitor.cpp
+++ b/tools/OperationMonitor.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "OperationMonitor.h"
 

--- a/tools/OperationMonitor.h
+++ b/tools/OperationMonitor.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_OPERATION_MONITOR_H
 #define TOOLS_OPERATION_MONITOR_H

--- a/tools/WorldDumper.cpp
+++ b/tools/WorldDumper.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "WorldDumper.h"
 

--- a/tools/WorldDumper.h
+++ b/tools/WorldDumper.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_WORLD_DUMPER_H
 #define TOOLS_WORLD_DUMPER_H

--- a/tools/WorldLoader.cpp
+++ b/tools/WorldLoader.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #include "WorldLoader.h"
 

--- a/tools/WorldLoader.h
+++ b/tools/WorldLoader.h
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 #ifndef TOOLS_WORLD_LOADER_H
 #define TOOLS_WORLD_LOADER_H

--- a/tools/cyaddrules.cpp
+++ b/tools/cyaddrules.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cyaddrules_index
 ///

--- a/tools/cycmd.cpp
+++ b/tools/cycmd.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cycmd_index
 ///

--- a/tools/cyconfig.cpp
+++ b/tools/cyconfig.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cyconfig_index
 ///

--- a/tools/cyconvertrules.cpp
+++ b/tools/cyconvertrules.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cyconvertrules_index
 ///

--- a/tools/cydb.cpp
+++ b/tools/cydb.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cydb_index
 ///

--- a/tools/cydumprules.cpp
+++ b/tools/cydumprules.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cydumprules_index
 ///

--- a/tools/cyloadrules.cpp
+++ b/tools/cyloadrules.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cyloadrules_index
 ///

--- a/tools/cypasswd.cpp
+++ b/tools/cypasswd.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cypasswd_index
 ///

--- a/tools/cypython.cpp
+++ b/tools/cypython.cpp
@@ -15,7 +15,6 @@
 // along with this program; if not, write to the Free Software Foundation,
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-// $Id$
 
 /// \page cypython_index
 ///


### PR DESCRIPTION
The legacy tags are causing build issues in Debian. Since we're no longer using CVS, removing the tags should have no impact. Thoughts?
