### PR TITLE
Fixed the long lines in the Mason Ruleset to be read easier

### DIFF
--- a/rulesets/mason/world/tasks/Baking.py
+++ b/rulesets/mason/world/tasks/Baking.py
@@ -71,7 +71,7 @@ class Baking(server.Task):
             if bcount == 1 :
                 local_ent = Entity(name = "castle_wall_run", type = "castle_wall_run", 
                                     location = chunk_loc)
-                create=Operation("create", local ent, to = self.target())
+                create=Operation("create", local_ent, to = self.target())
                 res.append(create)
 
         if ecount == 2 :

--- a/rulesets/mason/world/tasks/Baking.py
+++ b/rulesets/mason/world/tasks/Baking.py
@@ -69,26 +69,36 @@ class Baking(server.Task):
         # Select which structure to produce depending on the recipe present in inventory
         if ecount == 1 :
             if bcount == 1 :
-                create=Operation("create", Entity(name = "castle_wall_run", type = "castle_wall_run", location = chunk_loc), to = self.target())
+                local_ent = Entity(name = "castle_wall_run", type = "castle_wall_run", 
+                                    location = chunk_loc)
+                create=Operation("create", local ent, to = self.target())
                 res.append(create)
 
         if ecount == 2 :
             if bcount == 4 :
-                create=Operation("create", Entity(name = "castle_wall_corner", type = "castle_wall_corner", location = chunk_loc), to = self.target())
+                local_ent = Entity(name = "castle_wall_corner", type = "castle_wall_corner",
+                                    location = chunk_loc)
+                create=Operation("create", local_ent, to = self.target())
                 res.append(create)
 
         if ecount == 3 :
             if bcount == 2 :
-                create=Operation("create", Entity(name = "castle_wall_stairs", type = "castle_wall_stairs", location = chunk_loc), to = self.target())
+                local_ent = Entity(name = "castle_wall_stairs", type = "castle_wall_stairs",
+                                    location = chunk_loc)
+                create=Operation("create", local_ent, to = self.target())
                 res.append(create)
 
             if bcount == 3 :
-                create=Operation("create", Entity(name = "castle_wall_gate", type = "castle_wall_gate", location = chunk_loc), to = self.target())
+                local_ent = Entity(name = "castle_wall_gate", type = "castle_wall_gate",
+                                    location = chunk_loc)
+                create=Operation("create", local_ent, to = self.target())
                 res.append(create)
 
         if ecount == 4 :
             if bcount == 3 :
-                create=Operation("create", Entity(name = "castle_house_a", type = "castle_house_a", location = chunk_loc), to = self.target())
+                local_ent = Entity(name = "castle_house_a", type = "castle_house_a",
+                                    location = chunk_loc)
+                create=Operation("create", local_ent, to = self.target())
                 res.append(create)
 
         # Consume the materials according to the recipe

--- a/rulesets/mason/world/tasks/Bisect.py
+++ b/rulesets/mason/world/tasks/Bisect.py
@@ -27,12 +27,17 @@ class Bisect(server.Task):
         """ Op handler for regular tick op """
         # print "Bisect.tick"
 
+        # Useful variables to help keep lines small and readable
+        char_loc = self.character.location
+        target_loc = self.target().location
+        target_loc_bbr = self.target().location.bbox.square_bounding_radius()
+
         if self.target is None:
             # print "Target is no more"
             self.irrelevant()
             return
 
-        if square_distance(self.character.location, self.target().location) > (self.target().location.bbox.square_bounding_radius() + 1):
+        if square_distance(char_loc, target_loc) > (target_loc_bbr + 1):
             self.rate = 0
             # print "Too far away"
             return self.next_tick(0.75)

--- a/rulesets/mason/world/tasks/BuildBloomery.py
+++ b/rulesets/mason/world/tasks/BuildBloomery.py
@@ -93,8 +93,8 @@ class BuildBloomery(server.Task):
             set = Operation("set", Entity(tar.id, status = -1), to = tar)
             res.append(set)
             count = count - 1
-
-        create=Operation("create", Entity(name = "bloomery", type = "bloomery", location = chunk_loc), to = target)
+        local_ent = Entity(name = "bloomery", type = "bloomery", location = chunk_loc)
+        create=Operation("create", local_ent, to = target)
         res.append(create)
         self.progress = 1
         self.irrelevant()

--- a/rulesets/mason/world/tasks/Cultivate.py
+++ b/rulesets/mason/world/tasks/Cultivate.py
@@ -34,12 +34,13 @@ class Cultivate(server.Task):
             return
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        entity_edges_dis = square_horizontal_edge_distance(self.character.location,
+                                                           self.target().location) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.progress = 0
             self.rate = 0
             return self.next_tick(1.75)

--- a/rulesets/mason/world/tasks/Destroying.py
+++ b/rulesets/mason/world/tasks/Destroying.py
@@ -52,12 +52,13 @@ class Destroying(server.Task):
             current_status = 1.0
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        entity_edges_dis = square_horizontal_edge_distance(self.character.location,
+                                                           self.target().location) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.progress = 1 - current_status
             self.rate = 0
             return self.next_tick(1.75)

--- a/rulesets/mason/world/tasks/Dragging.py
+++ b/rulesets/mason/world/tasks/Dragging.py
@@ -62,7 +62,8 @@ class Dragging(server.Task):
 
         chunk_loc.coordinates = self.pos
         # Move the entity to user's position.
-        res = res + Operation("move", Entity(self.target().id, location = chunk_loc), to = self.target())
+        res = res + Operation("move", Entity(self.target().id,
+                                             location = chunk_loc), to = self.target())
         res.append(self.next_tick(0.75))
 
         return res

--- a/rulesets/mason/world/tasks/Drying.py
+++ b/rulesets/mason/world/tasks/Drying.py
@@ -34,7 +34,11 @@ class Drying(server.Task):
         self.rate = 0.2 / 0.75
         self.progress += 0.5
 
-        if square_distance(self.character.location, self.target().location) > self.target().location.bbox.square_bounding_radius():
+        char_loc = self.character.location
+        target_loc = self.target().location
+        target_loc_radius = self.target().location.bbox.square_bounding_radius()
+
+        if square_distance(char_loc, target_loc) > target_loc_radius:
             self.rate = 0
             # print "Too far away"
             return self.next_tick(0.75)

--- a/rulesets/mason/world/tasks/Earthwall.py
+++ b/rulesets/mason/world/tasks/Earthwall.py
@@ -84,7 +84,9 @@ class Earthwall(server.Task):
             res.append(set)
             count = count - 1
 
-        create=Operation("create", Entity(name = "earth_wall", type = "earth_wall", location = chunk_loc), to = self.target())
+        create=Operation("create", Entity(name = "earth_wall",
+                         type = "earth_wall", location = chunk_loc),
+                         to = self.target())
         res.append(create)
         self.progress = 1
         self.irrelevant()

--- a/rulesets/mason/world/tasks/Fishing.py
+++ b/rulesets/mason/world/tasks/Fishing.py
@@ -58,10 +58,15 @@ class Fishing(server.Task):
         bait_vector = Vector3D(0, 0, -0.5)
         bait_loc = float_loc.copy()
         bait_loc.coordinates = bait_loc.coordinates + bait_vector
-        
-        res = Operation("create", Entity(name = "bobber", parents = ["bobber"], location = float_loc), to = self.target())
-        res = res + Operation("move", Entity(bait.id, location = bait_loc), to = bait)
-        res = res + Operation("create", Entity(parents = ["hook"], location = Location(bait, Point3D(0,0,0))), to = bait)
+
+        # local ents to help the next block of lines maintain a nice standard
+        bobber_ent = Entity(name = "bobber", parents = ["bobber"], location = float_loc)
+        bait_ent = Entity(bait.id, location = bait_loc)
+        hook_ent = Entity(parents = ["hook"], location = Location(bait, Point3D(0,0,0)))
+
+        res = Operation("create", bobber_ent, to = self.target())
+        res = res + Operation("move", bait_ent, to = bait)
+        res = res + Operation("create", hook_ent, to = bait)
         return res
 
     def tick_operation(self, op):
@@ -94,7 +99,9 @@ class Fishing(server.Task):
                 return
             fish = self.hook().location.parent
             #TODO: add check to ensure that the fish's parent isn't world or something like that
-            res.append(Operation("move", Entity(fish.id, location = Location(self.character, Point3D(0,0,0))), to=fish))
+            fish_ent = Entity(fish.id, location = Location(self.character, Point3D(0,0,0)))
+
+            res.append(Operation("move", fish_ent, to=fish))
             self.progress = 1
             self.irrelevant()
         return res

--- a/rulesets/mason/world/tasks/Furnishings.py
+++ b/rulesets/mason/world/tasks/Furnishings.py
@@ -68,13 +68,18 @@ class Furnishings(server.Task):
             #create the table
             #Table base
             lbbox=[-.2,-.2,-.5,.2,.2,.5]#local bbox
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+
+            # various useful entities
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,bbox=lbbox,mode="fixed")
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
             #create the table top
             offset=Vector3D(0,0,1)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
             lbbox=[-.7,-.7,-.1,.7,.7,.1]
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
         if self.fname=="Chair":
             #Making chair
@@ -88,7 +93,9 @@ class Furnishings(server.Task):
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(.2,.2,0)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed"), to = target)
+
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed")
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
 
 
@@ -96,21 +103,24 @@ class Furnishings(server.Task):
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(-.2,.2,0)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed"), to = target)
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed")
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
 
             #leg 3
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(-.2,-.2,0)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed"), to = target)
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed")
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
 
             #leg 4
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(.2,-.2,0)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed"), to = target)
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,mode="fixed")
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
 
 
@@ -120,7 +130,8 @@ class Furnishings(server.Task):
             offset=Vector3D(0,0,.5)
             lbbox=[-.3,-.3,-.1,.3,.3,.1]#Local bbox
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
 
             #create the back of the seat
@@ -128,7 +139,8 @@ class Furnishings(server.Task):
             offset=Vector3D(-.3,0,.75)
             lbbox=[-.1,-.3,-.4,.1,.3,.4]#local bbox
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
             
         
@@ -141,7 +153,8 @@ class Furnishings(server.Task):
                 count = count - 1
             #create the Floor, it is one large wood
             lbbox=[-2,-2,-.1,2,2,.1]#local bbox
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
         if self.fname=="Siding":
             #Making wooden siding with window
@@ -153,28 +166,32 @@ class Furnishings(server.Task):
             #Siding is made of 4 components so it looks like we have a window
             #Bottom part
             lbbox=[-3,-.1,-1,3,.1,2]
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
             #Top part
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(0,0,4)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
             lbbox=[-3,-.1,-1,3,.1,2]
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
             #left part
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(-2,0,2)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
             lbbox=[-1,-.1,-.5,1,.1,.5]
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
             #Right part
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(2,0,2)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
             lbbox=[-1,-.1,-.5,1,.1,.5]
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
         if self.fname=="Fireplace":
             #Making Fireplace
@@ -189,28 +206,32 @@ class Furnishings(server.Task):
             res.append(create)
             #make floor of fireplace
             lbbox=[-2,-1,-.1,2,1,.1]#local bbox
-            create=Operation("create", Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            boulder_ent = Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", boulder_ent, to = target)
             res.append(create)
             #make wall 1 of fireplace
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(-1.6,0,0)
             lbbox=[-.1,-1,-.1,.1,1,1.5]
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            boulder_ent = Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", boulder_ent, to = target)
             res.append(create)
             #make wall 2 of fireplace
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(1.6,0,0)
             lbbox=[-.1,-1,-.1,.1,1,1.5]
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            boulder_ent = Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", boulder_ent, to = target)
             res.append(create)
             #make back of fireplace
             chunk_loc.coordinates =Point3D([0,0,0])
             offset=Vector3D(0,-.6,0)
             lbbox=[-2,-.1,-.1,2,.1,1.5]
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            boulder_ent = Entity(name = "boulder", type = "boulder", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", boulder_ent, to = target)
             res.append(create)
         if self.fname=="Wallframe":
             #Bottom part of wall frame
@@ -265,14 +286,16 @@ class Furnishings(server.Task):
             lbbox=[-4,-4,-.1,4,4,.3]#local bbox
             offset=Vector3D(0,0,5)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            wood_ent = Entity(name = "wood", type = "wood", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", wood_ent, to = target)
             res.append(create)
             #create column
             chunk_loc.coordinates =Point3D([0,0,0])
             lbbox=[-.5,-.5,-.1,.5,.5,6]#local bbox
             offset=Vector3D(0,0,0)
             chunk_loc.coordinates=chunk_loc.coordinates+offset
-            create=Operation("create", Entity(name = "lumber", type = "lumber", location = chunk_loc,bbox=lbbox,mode="fixed"), to = target)
+            lumber_ent = Entity(name = "lumber", type = "lumber", location = chunk_loc,bbox=lbbox,mode="fixed")
+            create=Operation("create", lumber_ent, to = target)
             res.append(create)
 
         self.progress =1
@@ -361,7 +384,8 @@ class Furnishings(server.Task):
             bbox1=[-lumberwidth,-.5,-lumberwidth,0,.5,lumberwidth]
         if(self.fname=="Siding"):
             bbox1=[-3,-.1,-3,3,.1,3]
-        create=Operation("create", Entity(name = self.fname, type = "construction",bbox=bbox1, location = chunk_loc), to = target)
+        random_ent = Entity(name = self.fname, type = "construction",bbox=bbox1, location = chunk_loc)
+        create=Operation("create", random_ent, to = target)
         create.setSerialno(0)
         res.append(create)
         res.append(self.next_tick(1.75))    

--- a/rulesets/mason/world/tasks/IronSmelting.py
+++ b/rulesets/mason/world/tasks/IronSmelting.py
@@ -38,7 +38,11 @@ class IronSmelting(server.Task):
 
         res=Oplist()
 
-        if square_distance(self.character.location, self.target().location) > self.target().location.bbox.square_bounding_radius() + 0.1:
+        char_loc = self.character.location
+        target_loc = self.target().location
+        target_box_sbr = self.target().location.bbox.square_bounding_radius()
+
+        if square_distance(char_loc, target_loc) > target_box_sbr + 0.1:
             self.rate = 0
             self.progress -= 0.1
             # no progress

--- a/rulesets/mason/world/tasks/Logging.py
+++ b/rulesets/mason/world/tasks/Logging.py
@@ -36,12 +36,13 @@ class Logging(server.Task):
         current_status = self.target().status
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        entity_edges_dis = square_horizontal_edge_distance(self.character.location,
+                                                           self.target().location) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.progress = 1 - current_status
             self.rate = 0
             return self.next_tick(1.75)

--- a/rulesets/mason/world/tasks/Pioneering.py
+++ b/rulesets/mason/world/tasks/Pioneering.py
@@ -73,15 +73,21 @@ class Pioneering(server.Task):
         # Select which structure to produce depending on the recipe present in inventory
         if rcount == 1 :
             if wcount == 1 and lcount == 0:
-                create=Operation("create", Entity(name = "sledge", type = "sledge", location = chunk_loc), to = self.target())
+                sledge_ent = Entity(name = "sledge", type = "sledge",
+                                    location = chunk_loc)
+                create=Operation("create", sledge_ent, to = self.target())
                 res.append(create)
 
             if wcount == 1 and lcount == 1:
-                create=Operation("create", Entity(name = "board_wall", type = "board_wall", location = chunk_loc), to = self.target())
+                board_wall_ent = Entity(name = "board_wall", type = "board_wall",
+                                        location = chunk_loc)
+                create=Operation("create", board_wall_ent, to = self.target())
                 res.append(create)
 
             if wcount == 0 and lcount == 2:
-                create=Operation("create", Entity(name = "palissade_unit", type = "palissade_unit", location = chunk_loc), to = self.target())
+                palissade_unnit_ent = Entity(name = "palissade_unit",
+                                             type = "palissade_unit", location = chunk_loc)
+                create=Operation("create", palissade_unnit_ent, to = self.target())
                 res.append(create)
 
             #if wcount == 2 and lcount == 1:
@@ -90,16 +96,21 @@ class Pioneering(server.Task):
 
         if rcount == 2 :
             if wcount == 1 and lcount == 0:
-                create=Operation("create", Entity(name = "fence_section", type = "fence_section", location = chunk_loc), to = self.target())
+                fence_section_ent = Entity(name = "fence_section", type = "fence_section",
+                                           location = chunk_loc)
+                create=Operation("create", fence_section_ent, to = self.target())
                 res.append(create)
 
             if wcount == 0 and lcount == 3:
-                create=Operation("create", Entity(name = "palissade_entry", type = "palissade_entry", location = chunk_loc), to = self.target())
+                palissade_entry_ent = Entity(name = "palissade_entry", type = "palissade_entry",
+                                             location = chunk_loc)
+                create=Operation("create", palissade_entry_ent, to = self.target())
                 res.append(create)
 
         if rcount == 3 :
             if wcount == 1 and lcount == 0:
-                create=Operation("create", Entity(name = "fence_gate", type = "fence_gate", location = chunk_loc), to = self.target())
+                fence_gate_ent = Entity(name = "fence_gate", type = "fence_gate", location = chunk_loc)
+                create=Operation("create", fence_gate_ent, to = self.target())
                 res.append(create)
 
 #            if wcount == 3 and lcount == 0:
@@ -107,7 +118,9 @@ class Pioneering(server.Task):
  #               res.append(create)
 
             if wcount == 0 and lcount == 5:
-                create=Operation("create", Entity(name = "palissade_circle", type = "palissade_circle", location = chunk_loc), to = self.target())
+                palissade_circle_ent = Entity(name = "palissade_circle",
+                                              type = "palissade_circle", location = chunk_loc)
+                create=Operation("create", palissade_circle_ent, to = self.target())
                 res.append(create)
 
         # Consume the materials according to the recipe

--- a/rulesets/mason/world/tasks/Pulling.py
+++ b/rulesets/mason/world/tasks/Pulling.py
@@ -37,7 +37,8 @@ class Pulling(server.Task):
             self.irrelevant()
             return
 
-        target_location = Location(self.target().location.parent, self.target().location.coordinates)
+        target_location = Location(self.target().location.parent,
+                                   self.target().location.coordinates)
         target_location.velocity=Vector3D(0,0,-0.5)
         new_loc = self.character.location.coordinates
         origin = self.points[0]
@@ -46,7 +47,10 @@ class Pulling(server.Task):
         target_entity_moving = Entity(self.target().id, location = target_location)
 
         # Replicate the diffrence in position to the corresponding change in height.
-        target_location = Location(self.target().location.parent, Point3D(self.target().location.coordinates.x, self.target().location.coordinates.y, self.target().location.coordinates.z + diff))
+        target_location = Location(self.target().location.parent,
+                                   Point3D(self.target().location.coordinates.x, 
+                                   self.target().location.coordinates.y, 
+                                   self.target().location.coordinates.z + diff))
         target_location.velocity=Vector3D(0,0,0)
         target_entity = Entity(self.target().id, location = target_location)
 

--- a/rulesets/mason/world/tasks/Ram.py
+++ b/rulesets/mason/world/tasks/Ram.py
@@ -34,14 +34,19 @@ class Ram(server.Task):
             self.irrelevant()
             return
 
-        if square_distance(self.character.location, self.target().location) > self.target().location.bbox.square_bounding_radius():
+        long_var = self.target().location.bbox.square_bounding_radius()
+        if square_distance(self.character.location,
+                           self.target().location) > long_var:
             return self.next_tick(1)
 
         target_location = Location(self.target().location.parent, self.target().location.coordinates)
         target_location.velocity=Vector3D(0,0,-0.5)
         target_entity_moving = Entity(self.target().id, location = target_location)
 
-        target_location = Location(self.target().location.parent, Point3D(self.target().location.coordinates.x, self.target().location.coordinates.y, self.target().location.coordinates.z - 0.1))
+        target_location = Location(self.target().location.parent,
+                                   Point3D(self.target().location.coordinates.x,
+                                   self.target().location.coordinates.y,
+                                   self.target().location.coordinates.z - 0.1))
         target_location.velocity=Vector3D(0,0,0)
         target_entity = Entity(self.target().id, location = target_location)
 

--- a/rulesets/mason/world/tasks/Repairing.py
+++ b/rulesets/mason/world/tasks/Repairing.py
@@ -54,12 +54,14 @@ class Repairing(server.Task):
             return
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        
+        entity_edges_dis = square_horizontal_edge_distance(self.character.location,
+                                                           self.target().location) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.progress = current_status
             self.rate = 0
             return self.next_tick(1.75)
@@ -75,7 +77,8 @@ class Repairing(server.Task):
             self.irrelevant()
 
         if current_status < 0.9:
-            set=Operation("set", Entity(self.target().id, status=current_status+0.1), to=self.target())
+            set=Operation("set", Entity(self.target().id,
+                                        status=current_status+0.1), to=self.target())
             res.append(set)
             consume =  self.consume_materials ()
             if consume : 

--- a/rulesets/mason/world/tasks/Sharpen.py
+++ b/rulesets/mason/world/tasks/Sharpen.py
@@ -38,12 +38,14 @@ class Sharpen(server.Task):
             new_status = self.target().status - 0.1
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        char_loc = self.character.location
+        target_loc = self.target().location
+        entity_edges_dis = square_horizontal_edge_distance(char_loc, target_loc) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.progress = 1 - new_status
             self.rate = 0
             return self.next_tick(1.75)
@@ -53,7 +55,8 @@ class Sharpen(server.Task):
             new_loc = self.target().location.copy()
             new_loc.bbox = self.target().location.bbox
             new_loc.orientation = self.target().location.orientation
-            create=Operation("create", Entity(name='stake',type='stake',location=new_loc), to=self.target())
+            create=Operation("create", Entity(name='stake',type='stake',
+                                              location=new_loc), to=self.target())
             res.append(create)
         
         set=Operation("set", Entity(self.target().id, status=new_status), to=self.target())

--- a/rulesets/mason/world/tasks/Sift.py
+++ b/rulesets/mason/world/tasks/Sift.py
@@ -85,9 +85,11 @@ class Sift(server.Task):
         quality = int(self.get_quality(self_loc.coordinates, self.target(), moisture))
         print quality
         for i in range(int(quality/2), quality):
-            res = res + Operation("create", Entity(name = "scrawny earthworm", parents = ["annelid"], location = self_loc), to=self.character)
+            earth_worm_ent = Entity(name = "scrawny earthworm", parents = ["annelid"], location = self_loc)
+            res = res + Operation("create", earth_worm_ent, to=self.character)
         for i in range(int((10-quality)/2), quality):
-            res = res + Operation("create", Entity(name = "juicy earthworm", parents = ["annelid"], location = self_loc), to=self.character)
+            earth_worm_ent = Entity(name = "juicy earthworm", parents = ["annelid"], location = self_loc)
+            res = res + Operation("create", earth_worm_ent, to=self.character)
 
         self.irrelevant()
         return res

--- a/rulesets/mason/world/tasks/Slaughter.py
+++ b/rulesets/mason/world/tasks/Slaughter.py
@@ -39,12 +39,14 @@ class Slaughter(server.Task):
             # print "setting target mass to ", self.count
 
         #Measure the distance between the entity horizontal edges. Else we won't be able to reach if either entity is too thick.
-        distance_between_entity_edges_squared = square_horizontal_edge_distance(self.character.location, self.target().location) 
+        char_loc = self.character.location
+        target_loc = self.target().location
+        entity_edges_dis = square_horizontal_edge_distance(char_loc, target_loc) 
         
         #Assume that a standard human can reach 1.5 meters, and use this to determine if we're close enough to be able to perform the logging
         standard_human_reach_squared=1.5*1.5
 
-        if distance_between_entity_edges_squared > standard_human_reach_squared:
+        if entity_edges_dis > standard_human_reach_squared:
             self.rate = 0
             # print "Too far away"
             return self.next_tick(1.75)

--- a/rulesets/mason/world/tasks/Slice.py
+++ b/rulesets/mason/world/tasks/Slice.py
@@ -33,7 +33,8 @@ class Slice(server.Task):
             self.irrelevant()
             return
 
-        if square_distance(self.character.location, target.location) > target.location.bbox.square_bounding_radius():
+        long_var = target.location.bbox.square_bounding_radius()
+        if square_distance(self.character.location, target.location) > long_var:
             self.rate = 0
             # print "Too far away"
             return self.next_tick(0.75)
@@ -80,7 +81,9 @@ class Slice(server.Task):
 
         slice_loc.orientation = target.location.orientation
 
-        create=Operation("create", Entity(name='wood', type='wood', location=slice_loc, bbox=slice_bbox), to=target)
+        create=Operation("create", Entity(name='wood', type='wood',
+                                          location=slice_loc, bbox=slice_bbox),
+                                          to=target)
         res.append(create)
 
         if width - self.width > self.width:

--- a/rulesets/mason/world/tasks/Trailblaze.py
+++ b/rulesets/mason/world/tasks/Trailblaze.py
@@ -43,7 +43,8 @@ class Trailblaze(server.Task):
             self.progress = 0
             if 'world' in target.type:
                 new_loc = Location(target, self.character.location.coordinates)
-                create = Operation("create", Entity(name='pile', type='pile', location = new_loc), to=target)
+                create = Operation("create", Entity(name='pile', type='pile',
+                                                    location = new_loc), to=target)
                 res.append(create)
                 self.points.append(self.character.location.coordinates)
             elif 'pile' in target.type:

--- a/rulesets/mason/world/tasks/Twirling.py
+++ b/rulesets/mason/world/tasks/Twirling.py
@@ -35,7 +35,8 @@ class Twirling(server.Task):
         self.rate = 0.5 / 0.75
         self.progress += 1
  
-        if square_distance(self.character.location, target.location) > target.location.bbox.square_bounding_radius():
+        long_var = target.location.bbox.square_bounding_radius()
+        if square_distance(self.character.location, target.location) > long_var:
             self.rate = 0
             # print "Too far away "
             return self.next_tick(0.75)

--- a/rulesets/mason/world/tasks/Woodenwall.py
+++ b/rulesets/mason/world/tasks/Woodenwall.py
@@ -86,7 +86,8 @@ class Woodenwall(server.Task):
             res.append(set)
             count = count - 1
 
-        create=Operation("create", Entity(name = "board_wall", type = "board_wall", location = chunk_loc), to = target)
+        create=Operation("create", Entity(name = "board_wall", type = "board_wall",
+                                          location = chunk_loc), to = target)
         res.append(create)
         self.progress = 1
         self.irrelevant()


### PR DESCRIPTION
I went through all the tasks in the Mason ruleset, and modified the super-long lines, to become shorter lines so that the code could be read easier. Further inspection will need to be done, to fully match Python standards, in all of the scripts.
