### PR TITLE
Adding bone_pile and bone part entity types.

### DIFF
--- a/data/deeds/bones.xml
+++ b/data/deeds/bones.xml
@@ -13,6 +13,10 @@
         </list>
         <string name="visibility">public</string>
       </map>
+      <map name="mass">
+        <float name="default">1</float>
+        <string name="visibility">public</string>
+      </map>
     </map>
     <string name="id">bone_pile</string>
     <string name="objtype">class</string>
@@ -32,6 +36,10 @@
           <float>0.257261</float>
           <float>0.060654</float>
         </list>
+        <string name="visibility">public</string>
+      </map>
+      <map name="mass">
+        <float name="default">1</float>
         <string name="visibility">public</string>
       </map>
     </map>
@@ -55,6 +63,10 @@
         </list>
         <string name="visibility">public</string>
       </map>
+      <map name="mass">
+        <float name="default">1</float>
+        <string name="visibility">public</string>
+      </map>
     </map>
     <string name="id">humerus</string>
     <string name="objtype">class</string>
@@ -74,6 +86,10 @@
           <float>0.140789</float>
           <float>0.183562</float>
         </list>
+        <string name="visibility">public</string>
+      </map>
+      <map name="mass">
+        <float name="default">1</float>
         <string name="visibility">public</string>
       </map>
     </map>
@@ -97,6 +113,10 @@
         </list>
         <string name="visibility">public</string>
       </map>
+      <map name="mass">
+        <float name="default">1</float>
+        <string name="visibility">public</string>
+      </map>
     </map>
     <string name="id">ribcage</string>
     <string name="objtype">class</string>
@@ -118,6 +138,10 @@
         </list>
         <string name="visibility">public</string>
       </map>
+      <map name="mass">
+        <float name="default">1</float>
+        <string name="visibility">public</string>
+      </map>
     </map>
     <string name="id">skull</string>
     <string name="objtype">class</string>
@@ -137,6 +161,10 @@
           <float>0.248019</float>
           <float>0.054941</float>
         </list>
+        <string name="visibility">public</string>
+      </map>
+      <map name="mass">
+        <float name="default">1</float>
         <string name="visibility">public</string>
       </map>
     </map>

--- a/data/deeds/bones.xml
+++ b/data/deeds/bones.xml
@@ -1,0 +1,150 @@
+<atlas>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.462754</float>
+          <float>-0.741266</float>
+          <float>-0.004131</float>
+          <float>0.567185</float>
+          <float>0.587145</float>
+          <float>0.183562</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">bone_pile</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.033521</float>
+          <float>-0.241064</float>
+          <float>0.000114001</float>
+          <float>0.056145</float>
+          <float>0.257261</float>
+          <float>0.060654</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">femur</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.022615</float>
+          <float>-0.168751</float>
+          <float>-9.69991e-05</float>
+          <float>0.023217</float>
+          <float>0.151354</float>
+          <float>0.045121</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">humerus</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.100088</float>
+          <float>-0.142615</float>
+          <float>-0.00211599</float>
+          <float>0.070666</float>
+          <float>0.140789</float>
+          <float>0.183562</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">pelvis</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.159639</float>
+          <float>-0.150846</float>
+          <float>-0.00116201</float>
+          <float>0.197961</float>
+          <float>0.152546</float>
+          <float>0.17369</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">ribcage</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.138691</float>
+          <float>-0.12053</float>
+          <float>-0.004131</float>
+          <float>0.097734</float>
+          <float>0.105192</float>
+          <float>0.160005</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">skull</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+  <map>
+    <map name="attributes">
+      <map name="bbox">
+        <list name="default">
+          <float>-0.033747</float>
+          <float>-0.24204</float>
+          <float>-0.000397999</float>
+          <float>0.036177</float>
+          <float>0.248019</float>
+          <float>0.054941</float>
+        </list>
+        <string name="visibility">public</string>
+      </map>
+    </map>
+    <string name="id">tibia</string>
+    <string name="objtype">class</string>
+    <list name="parents">
+      <string>thing</string>
+    </list>
+  </map>
+
+</atlas>

--- a/data/deeds/deeds.xml
+++ b/data/deeds/deeds.xml
@@ -2,20 +2,6 @@
 
   <map>
     <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">arm</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
       <map name="bbox">
         <list name="default">
           <float>-0.25</float>
@@ -447,34 +433,6 @@
 
   <map>
     <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">pelvis</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">ribcage</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
       <map name="bbox">
         <list name="default">
           <float>-0.732675</float>
@@ -488,20 +446,6 @@
       </map>
     </map>
     <string name="id">shelf_table</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">shin</string>
     <string name="objtype">class</string>
     <list name="parents">
       <string>thing</string>
@@ -548,20 +492,6 @@
       </map>
     </map>
     <string name="id">simple_shelf</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">skull</string>
     <string name="objtype">class</string>
     <list name="parents">
       <string>thing</string>
@@ -629,20 +559,6 @@
       </map>
     </map>
     <string name="id">table</string>
-    <string name="objtype">class</string>
-    <list name="parents">
-      <string>thing</string>
-    </list>
-  </map>
-
-  <map>
-    <map name="attributes">
-      <map name="mass">
-        <float name="default">1</float>
-        <string name="visibility">public</string>
-      </map>
-    </map>
-    <string name="id">thigh</string>
     <string name="objtype">class</string>
     <list name="parents">
       <string>thing</string>


### PR DESCRIPTION
Adding a bone_pile and the parts skull, pelvis, ribcage, femur, humerus, tibia entity types for worldforge-media-skeleton-parts blueprint. Removed the old type definitions from deeds.xml and moved all bone part definitions into bones.xml.