### PR TITLE
Entityfilter testfix

### DIFF
--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -6,13 +6,33 @@
 #endif
 
 #define private public
+#define protected public
 
 #include "TestBase.h"
 
+#include "rulesets/entityfilter/Filter.h"
 #include "rulesets/entityfilter/ParserDefinitions.h"
 #include "rulesets/entityfilter/Providers.h"
 
-#include <boost/spirit/include/qi.hpp>
+#include "rulesets/EntityProperty.h"
+#include "rulesets/Domain.h"
+#include "rulesets/AtlasProperties.h"
+#include "rulesets/OutfitProperty.h"
+#include "rulesets/BBoxProperty.h"
+#include "common/Property.h"
+#include "common/BaseWorld.h"
+#include "common/log.h"
+#include "common/Inheritance.h"
+
+#include "rulesets/Entity.h"
+#include "common/TypeNode.h"
+
+#include <wfmath/point.h>
+#include <Atlas/Objects/Anonymous.h>
+
+#include <cassert>
+
+static std::map<std::string, TypeNode*> types;
 
 using namespace EntityFilter;
 using namespace boost::spirit;
@@ -21,14 +41,8 @@ using namespace boost::spirit;
 ///correct predicates for given queries
 class ParserTest : public Cyphesis::TestBase {
     private:
-        Predicate *m_predicate;
-        ProviderFactory *m_provider_factory;
-
-        //Grammar definition for testing
-        parser::query_parser<std::string::const_iterator> m_grammar;
-
         //A helper function to build a predicate for a given query
-        Predicate* ConstructPredicate(std::string query);
+        Predicate* ConstructPredicate(const std::string &query);
     public:
         ParserTest();
 
@@ -46,59 +60,184 @@ ParserTest::ParserTest()
 
 void ParserTest::setup()
 {
-    m_provider_factory = new ProviderFactory();
-    m_grammar = parser::query_parser<std::string::const_iterator>(
-            m_provider_factory);
 }
 
 void ParserTest::teardown()
 {
-    delete m_grammar;
-    delete m_provider_factory;
 }
 
 void ParserTest::test_ComparisonOperators()
 {
-    using ComparePredicate::Comparator;
     ComparePredicate *pred;
 
-    pred = ConstructPredicate("1 = 2");
-    assert(pred->m_comparator == Comparator::EQUALS);
+    pred = (ComparePredicate*)ConstructPredicate("1 = 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::EQUALS);
     delete pred;
 
-    pred = ConstructPredicate("1 != 2");
-    assert(pred->m_comparator == Comparator::NOT_EQUALS);
+    pred = (ComparePredicate*)ConstructPredicate("1 != 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::NOT_EQUALS);
     delete pred;
 
-    pred = ConstructPredicate("1 > 2");
-    assert(pred->m_comparator == Comparator::GREATER);
+    pred = (ComparePredicate*)ConstructPredicate("1 > 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::GREATER);
     delete pred;
 
-    pred = ConstructPredicate("1 < 2");
-    assert(pred->m_comparator == Comparator::LESS);
+    pred = (ComparePredicate*)ConstructPredicate("1 < 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::LESS);
     delete pred;
 
-    pred = ConstructPredicate("1 <= 2");
-    assert(pred->m_comparator == Comparator::GREATER_EQUAL);
+    pred = (ComparePredicate*)ConstructPredicate("1 <= 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::GREATER_EQUAL);
     delete pred;
 
-    pred = ConstructPredicate("1 >= 2");
-    assert(pred->m_comparator == Comparator::LESS_EQUAL);
+    pred = (ComparePredicate*)ConstructPredicate("1 >= 2");
+    assert(pred->m_comparator == ComparePredicate::Comparator::LESS_EQUAL);
     delete pred;
 }
 
-Predicate* ParserTest::ConstructPredicate(std::string query)
+Predicate* ParserTest::ConstructPredicate(const std::string &query)
 {
-    std::string what = "2 < 1";
     auto iter_begin = query.begin();
     auto iter_end = query.end();
+    ProviderFactory* factory = new ProviderFactory();
+    parser::query_parser<std::string::const_iterator> grammar(factory);
 
-    bool parse_success = qi::phrase_parse(iter_begin, iter_end, m_grammar,
-                                          boost::spirit::ascii::space,
-                                          m_predicate);
+    Predicate* pred;
+
+    bool parse_success = qi::phrase_parse(iter_begin, iter_end, grammar,
+                                             boost::spirit::ascii::space, pred);
+
     if (!(parse_success && iter_begin == iter_end)) {
         throw std::invalid_argument(
                 "Attempted creating entity filter with invalid query");
     }
 
+    return pred;
+
+}
+
+int main(int argc, char ** argv)
+{
+    ParserTest t;
+
+    return t.run();
+}
+
+//Stubs
+
+
+#include "stubs/common/stubVariable.h"
+#include "stubs/common/stubMonitors.h"
+#include "stubs/rulesets/stubDomainProperty.h"
+#include "stubs/rulesets/stubIdProperty.h"
+
+ContainsProperty::ContainsProperty(LocatedEntitySet & data) :
+        PropertyBase(per_ephem), m_data(data)
+{
+}
+
+int ContainsProperty::get(Atlas::Message::Element & e) const
+{
+    return 0;
+}
+
+void ContainsProperty::set(const Atlas::Message::Element & e)
+{
+}
+
+void ContainsProperty::add(const std::string & s,
+                           const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+
+ContainsProperty * ContainsProperty::copy() const
+{
+    return 0;
+}
+
+namespace Atlas
+{
+namespace Objects
+{
+namespace Operation
+{
+int ACTUATE_NO = -1;
+int ATTACK_NO = -1;
+int EAT_NO = -1;
+int NOURISH_NO = -1;
+int SETUP_NO = -1;
+int TICK_NO = -1;
+int UPDATE_NO = -1;
+int RELAY_NO = -1;
+}
+}
+}
+Router::Router(const std::string & id, long intId) :
+        m_id(id), m_intId(intId)
+{
+}
+
+Router::~Router()
+{
+}
+
+void Router::addToMessage(Atlas::Message::MapType & omap) const
+{
+}
+
+void Router::addToEntity(const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+BaseWorld*BaseWorld::m_instance = 0;
+BaseWorld::BaseWorld(LocatedEntity & gw) :
+        m_gameWorld(gw)
+{
+    m_instance = this;
+}
+
+BaseWorld::~BaseWorld()
+{
+    m_instance = 0;
+}
+
+LocatedEntity * BaseWorld::getEntity(const std::string & id) const
+{
+    return 0;
+}
+
+void Location::addToMessage(MapType & omap) const
+{
+}
+
+Location::Location() :
+        m_loc(0)
+{
+}
+
+void Location::addToEntity(const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+void Location::modifyBBox()
+{
+}
+
+
+Inheritance::Inheritance() {}
+
+Inheritance & Inheritance::instance()
+{
+    return *(new Inheritance());
+}
+
+const TypeNode * Inheritance::getType(const std::string & parent)
+{
+    auto I = types.find(parent);
+    if (I == types.end()) {
+        return 0;
+    }
+    return I->second;
+}
+
+void log(LogLevel lvl, const std::string & msg)
+{
 }

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -5,6 +5,8 @@
 #define DEBUG
 #endif
 
+#define private public
+
 #include "TestBase.h"
 
 #include "rulesets/entityfilter/ParserDefinitions.h"
@@ -57,7 +59,32 @@ void ParserTest::teardown()
 
 void ParserTest::test_ComparisonOperators()
 {
+    using ComparePredicate::Comparator;
+    ComparePredicate *pred;
 
+    pred = ConstructPredicate("1 = 2");
+    assert(pred->m_comparator == Comparator::EQUALS);
+    delete pred;
+
+    pred = ConstructPredicate("1 != 2");
+    assert(pred->m_comparator == Comparator::NOT_EQUALS);
+    delete pred;
+
+    pred = ConstructPredicate("1 > 2");
+    assert(pred->m_comparator == Comparator::GREATER);
+    delete pred;
+
+    pred = ConstructPredicate("1 < 2");
+    assert(pred->m_comparator == Comparator::LESS);
+    delete pred;
+
+    pred = ConstructPredicate("1 <= 2");
+    assert(pred->m_comparator == Comparator::GREATER_EQUAL);
+    delete pred;
+
+    pred = ConstructPredicate("1 >= 2");
+    assert(pred->m_comparator == Comparator::LESS_EQUAL);
+    delete pred;
 }
 
 Predicate* ParserTest::ConstructPredicate(std::string query)

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -56,6 +56,8 @@ class ParserTest : public Cyphesis::TestBase {
 
 ParserTest::ParserTest()
 {
+    ADD_TEST(ParserTest::test_ComparisonOperators);
+    ADD_TEST(ParserTest::test_LogicalOperators);
 }
 
 void ParserTest::setup()
@@ -87,12 +89,16 @@ void ParserTest::test_ComparisonOperators()
     delete pred;
 
     pred = (ComparePredicate*)ConstructPredicate("1 <= 2");
-    assert(pred->m_comparator == ComparePredicate::Comparator::GREATER_EQUAL);
+    assert(pred->m_comparator == ComparePredicate::Comparator::LESS_EQUAL);
     delete pred;
 
     pred = (ComparePredicate*)ConstructPredicate("1 >= 2");
-    assert(pred->m_comparator == ComparePredicate::Comparator::LESS_EQUAL);
+    assert(pred->m_comparator == ComparePredicate::Comparator::GREATER_EQUAL);
     delete pred;
+}
+
+void ParserTest::test_LogicalOperators()
+{
 }
 
 Predicate* ParserTest::ConstructPredicate(const std::string &query)
@@ -105,7 +111,7 @@ Predicate* ParserTest::ConstructPredicate(const std::string &query)
     Predicate* pred;
 
     bool parse_success = qi::phrase_parse(iter_begin, iter_end, grammar,
-                                             boost::spirit::ascii::space, pred);
+                                          boost::spirit::ascii::space, pred);
 
     if (!(parse_success && iter_begin == iter_end)) {
         throw std::invalid_argument(
@@ -124,7 +130,6 @@ int main(int argc, char ** argv)
 }
 
 //Stubs
-
 
 #include "stubs/common/stubVariable.h"
 #include "stubs/common/stubMonitors.h"
@@ -221,8 +226,9 @@ void Location::modifyBBox()
 {
 }
 
-
-Inheritance::Inheritance() {}
+Inheritance::Inheritance()
+{
+}
 
 Inheritance & Inheritance::instance()
 {

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -1,0 +1,38 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#ifndef DEBUG
+#define DEBUG
+#endif
+
+#include "TestBase.h"
+
+
+
+class ParserTest : public Cyphesis::TestBase
+{
+  private:
+
+  public:
+        ParserTest();
+
+    void setup();
+    void teardown();
+
+};
+
+ParserTest::ParserTest()
+{
+
+}
+
+void ParserTest::setup()
+{
+
+}
+
+void ParserTest::teardown()
+{
+
+}
+

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -95,10 +95,44 @@ void ParserTest::test_ComparisonOperators()
     pred = (ComparePredicate*)ConstructPredicate("1 >= 2");
     assert(pred->m_comparator == ComparePredicate::Comparator::GREATER_EQUAL);
     delete pred;
+
+    pred = (ComparePredicate*)ConstructPredicate("entity.container contains 1");
+    assert(pred->m_comparator == ComparePredicate::Comparator::CONTAINS);
+    delete pred;
+
+    pred = (ComparePredicate*)ConstructPredicate("1 in entity.container");
+    assert(pred->m_comparator == ComparePredicate::Comparator::IN);
+    delete pred;
+
+    //Instance_of can only be created for existing types
+    TypeNode* thingType = new TypeNode("thing");
+    types["thing"] = thingType;
+    pred = (ComparePredicate*)ConstructPredicate(
+            "types.thing instance_of entity.type");
+    assert(pred->m_comparator == ComparePredicate::Comparator::INSTANCE_OF);
+    delete pred;
+    types["thing"] = NULL;
+    delete thingType;
+
+    try { //Should throw an exception for nonexisting type
+        pred = (ComparePredicate*)ConstructPredicate(
+                "types.nonexistant instance_of entity.type");
+        assert(false);
+    } catch (std::invalid_argument &e) {
+    }
 }
 
 void ParserTest::test_LogicalOperators()
 {
+    Predicate *pred;
+
+    pred = ConstructPredicate("1 = 2 or 3 = 4");
+    assert(typeid(*pred) == typeid(OrPredicate));
+    delete pred;
+
+    pred = ConstructPredicate("1 = 2 and 3 = 4");
+    assert(typeid(*pred) == typeid(AndPredicate));
+    delete pred;
 }
 
 Predicate* ParserTest::ConstructPredicate(const std::string &query)

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -7,32 +7,71 @@
 
 #include "TestBase.h"
 
+#include "rulesets/entityfilter/ParserDefinitions.h"
+#include "rulesets/entityfilter/Providers.h"
 
+#include <boost/spirit/include/qi.hpp>
 
-class ParserTest : public Cyphesis::TestBase
-{
-  private:
+using namespace EntityFilter;
+using namespace boost::spirit;
 
-  public:
+///\These tests aim at verifying that entity filter parser builds
+///correct predicates for given queries
+class ParserTest : public Cyphesis::TestBase {
+    private:
+        Predicate *m_predicate;
+        ProviderFactory *m_provider_factory;
+
+        //Grammar definition for testing
+        parser::query_parser<std::string::const_iterator> m_grammar;
+
+        //A helper function to build a predicate for a given query
+        Predicate* ConstructPredicate(std::string query);
+    public:
         ParserTest();
 
-    void setup();
-    void teardown();
+        void setup();
+        void teardown();
+
+        void test_ComparisonOperators();
+        void test_LogicalOperators();
 
 };
 
 ParserTest::ParserTest()
 {
-
 }
 
 void ParserTest::setup()
 {
-
+    m_provider_factory = new ProviderFactory();
+    m_grammar = parser::query_parser<std::string::const_iterator>(
+            m_provider_factory);
 }
 
 void ParserTest::teardown()
 {
+    delete m_grammar;
+    delete m_provider_factory;
+}
+
+void ParserTest::test_ComparisonOperators()
+{
 
 }
 
+Predicate* ParserTest::ConstructPredicate(std::string query)
+{
+    std::string what = "2 < 1";
+    auto iter_begin = query.begin();
+    auto iter_end = query.end();
+
+    bool parse_success = qi::phrase_parse(iter_begin, iter_end, m_grammar,
+                                          boost::spirit::ascii::space,
+                                          m_predicate);
+    if (!(parse_success && iter_begin == iter_end)) {
+        throw std::invalid_argument(
+                "Attempted creating entity filter with invalid query");
+    }
+
+}

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -51,6 +51,7 @@ class ParserTest : public Cyphesis::TestBase {
 
         void test_ComparisonOperators();
         void test_LogicalOperators();
+        void test_Literals();
 
 };
 
@@ -58,6 +59,7 @@ ParserTest::ParserTest()
 {
     ADD_TEST(ParserTest::test_ComparisonOperators);
     ADD_TEST(ParserTest::test_LogicalOperators);
+    ADD_TEST(ParserTest::test_Literals);
 }
 
 void ParserTest::setup()
@@ -133,6 +135,40 @@ void ParserTest::test_LogicalOperators()
     pred = ConstructPredicate("1 = 2 and 3 = 4");
     assert(typeid(*pred) == typeid(AndPredicate));
     delete pred;
+}
+
+void ParserTest::test_Literals()
+{
+    ComparePredicate *pred;
+    using Atlas::Message::Element;
+
+    //Test int and single quote string
+    pred = (ComparePredicate*)ConstructPredicate("1 = '1'");
+    FixedElementProvider *lhs = (FixedElementProvider *)pred->m_lhs;
+    FixedElementProvider *rhs = (FixedElementProvider *)pred->m_rhs;
+
+    ASSERT_TRUE(lhs->m_element == Element(1));
+    ASSERT_TRUE(rhs->m_element == Element("1"));
+    delete pred;
+
+    //Test double and bool
+    pred = (ComparePredicate*)ConstructPredicate("1.25 = true");
+    lhs = (FixedElementProvider *)pred->m_lhs;
+    rhs = (FixedElementProvider *)pred->m_rhs;
+
+    ASSERT_TRUE(lhs->m_element == Element(1.25));
+    ASSERT_TRUE(rhs->m_element == Element(true));
+    delete pred;
+
+    //Test list and double quoted string
+    pred = (ComparePredicate*)ConstructPredicate("[1, 2, 3] = '\"literal\"'");
+    lhs = (FixedElementProvider *)pred->m_lhs;
+    rhs = (FixedElementProvider *)pred->m_rhs;
+
+    ASSERT_TRUE(lhs->m_element == Element(std::vector<Element> { 1, 2, 3 }));
+    ASSERT_TRUE(rhs->m_element == Element("\"literal\""));
+    delete pred;
+
 }
 
 Predicate* ParserTest::ConstructPredicate(const std::string &query)

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -69,6 +69,8 @@ class ProvidersTest : public Cyphesis::TestBase {
         void test_BBoxProviders();
         ///\Test Outfit providers
         void test_OutfitProviders();
+        ///\Test comparator predicates
+        void test_ComparePredicates();
 
 };
 
@@ -156,11 +158,61 @@ void ProvidersTest::test_OutfitProviders()
     assert(value.String() == "green");
 }
 
+void ProvidersTest::test_ComparePredicates()
+{
+    //entity.type = types.barrel
+    auto lhs_provider1 = CreateProvider( { "entity", "type" });
+    auto rhs_provider1 = CreateProvider( { "types", "barrel" });
+
+    ComparePredicate compPred1(lhs_provider1, rhs_provider1,
+                               ComparePredicate::Comparator::INSTANCE_OF);
+    assert(compPred1.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume
+    auto lhs_provider2 = CreateProvider( { "entity", "bbox", "volume" });
+
+    //entity.bbox.volume = 48
+    ComparePredicate compPred2(lhs_provider2, new FixedElementProvider(48.0f),
+                               ComparePredicate::Comparator::EQUALS);
+    assert(compPred2.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume = 1
+    ComparePredicate compPred3(lhs_provider2, new FixedElementProvider(1.0f),
+                               ComparePredicate::Comparator::EQUALS);
+    assert(!compPred3.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume != 1
+    ComparePredicate compPred4(lhs_provider2, new FixedElementProvider(1.0f),
+                               ComparePredicate::Comparator::NOT_EQUALS);
+    assert(compPred4.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume > 0
+    ComparePredicate compPred5(lhs_provider2, new FixedElementProvider(0.0f),
+                               ComparePredicate::Comparator::GREATER);
+    assert(compPred5.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume >= 1
+    ComparePredicate compPred6(lhs_provider2, new FixedElementProvider(1.0f),
+                               ComparePredicate::Comparator::GREATER_EQUAL);
+    assert(compPred6.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume < 5
+    ComparePredicate compPred7(lhs_provider2, new FixedElementProvider(5.0f),
+                               ComparePredicate::Comparator::LESS);
+    assert(!compPred7.isMatch(QueryContext { *m_b1 }));
+
+    //entity.bbox.volume <= 48
+    ComparePredicate compPred8(lhs_provider2, new FixedElementProvider(48.0f),
+                               ComparePredicate::Comparator::LESS_EQUAL);
+    assert(compPred8.isMatch(QueryContext { *m_b1 }));
+}
+
 ProvidersTest::ProvidersTest()
 {
     ADD_TEST(ProvidersTest::test_EntityProperty);
     ADD_TEST(ProvidersTest::test_BBoxProviders);
     ADD_TEST(ProvidersTest::test_OutfitProviders);
+    ADD_TEST(ProvidersTest::test_ComparePredicates);
 }
 
 void ProvidersTest::setup()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -138,23 +138,25 @@ void ProvidersTest::test_OutfitProviders()
 {
     Atlas::Message::Element value;
     //Check if we get the right entity in outfit query
-    auto provider = CreateProvider({"entity", "outfit", "hands"});
-    provider->value(value, QueryContext{*m_ch1});
-    ASSERT_EQUAL(*(Entity**)value.Ptr(), m_glovesEntity);
+    auto provider = CreateProvider( { "entity", "outfit", "hands" });
+    provider->value(value, QueryContext { *m_ch1 });
+    assert(*(Entity** )value.Ptr() ==  m_glovesEntity);
 
     //Check for outfit's property query
-    provider = CreateProvider({"entity", "outfit", "hands", "color"});
-    provider->value(value, QueryContext{*m_ch1});
+    provider = CreateProvider( { "entity", "outfit", "hands", "color" });
+    provider->value(value, QueryContext { *m_ch1 });
     assert(value.String() == "brown");
 
     //Check if we get the right entity in nested outfit query
-    provider = CreateProvider({"entity", "outfit", "hands", "outfit", "thumb"});
-    provider->value(value, QueryContext{*m_ch1});
-    assert(*(Entity**)value.Ptr() == m_cloth);
+    provider = CreateProvider(
+            { "entity", "outfit", "hands", "outfit", "thumb" });
+    provider->value(value, QueryContext { *m_ch1 });
+    assert(*(Entity** )value.Ptr() == m_cloth);
 
     //Check for nested outfit's property
-    provider = CreateProvider({"entity", "outfit", "hands", "outfit", "thumb", "color"});
-    provider->value(value, QueryContext{*m_ch1});
+    provider = CreateProvider( { "entity", "outfit", "hands", "outfit", "thumb",
+            "color" });
+    provider->value(value, QueryContext { *m_ch1 });
     assert(value.String() == "green");
 }
 

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -1,3 +1,5 @@
+
+
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
@@ -6,6 +8,30 @@
 #endif
 
 #include "TestBase.h"
+
+#include "rulesets/entityfilter/Filter.h"
+#include "rulesets/entityfilter/ParserDefinitions.h"
+#include "rulesets/entityfilter/Providers.h"
+
+#include "rulesets/EntityProperty.h"
+#include "rulesets/Domain.h"
+#include "rulesets/AtlasProperties.h"
+#include "rulesets/OutfitProperty.h"
+#include "rulesets/BBoxProperty.h"
+#include "common/Property.h"
+#include "common/BaseWorld.h"
+#include "common/log.h"
+#include "common/Inheritance.h"
+
+#include "rulesets/Entity.h"
+#include "common/TypeNode.h"
+
+#include <wfmath/point.h>
+#include <Atlas/Objects/Anonymous.h>
+
+#include <cassert>
+
+static std::map<std::string, TypeNode*> types;
 
 class ProvidersTest : public Cyphesis::TestBase {
     private:
@@ -33,3 +59,130 @@ void ProvidersTest::teardown()
 
 }
 
+
+
+int main(){
+    ProvidersTest t;
+
+    t.run();
+}
+
+
+//Stubs
+
+
+#include "stubs/common/stubVariable.h"
+#include "stubs/common/stubMonitors.h"
+#include "stubs/rulesets/stubDomainProperty.h"
+#include "stubs/rulesets/stubIdProperty.h"
+
+ContainsProperty::ContainsProperty(LocatedEntitySet & data) :
+        PropertyBase(per_ephem), m_data(data)
+{
+}
+
+int ContainsProperty::get(Atlas::Message::Element & e) const
+{
+    return 0;
+}
+
+void ContainsProperty::set(const Atlas::Message::Element & e)
+{
+}
+
+void ContainsProperty::add(const std::string & s,
+                           const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+
+ContainsProperty * ContainsProperty::copy() const
+{
+    return 0;
+}
+
+namespace Atlas
+{
+namespace Objects
+{
+namespace Operation
+{
+int ACTUATE_NO = -1;
+int ATTACK_NO = -1;
+int EAT_NO = -1;
+int NOURISH_NO = -1;
+int SETUP_NO = -1;
+int TICK_NO = -1;
+int UPDATE_NO = -1;
+int RELAY_NO = -1;
+}
+}
+}
+Router::Router(const std::string & id, long intId) :
+        m_id(id), m_intId(intId)
+{
+}
+
+Router::~Router()
+{
+}
+
+void Router::addToMessage(Atlas::Message::MapType & omap) const
+{
+}
+
+void Router::addToEntity(const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+BaseWorld*BaseWorld::m_instance = 0;
+BaseWorld::BaseWorld(LocatedEntity & gw) :
+        m_gameWorld(gw)
+{
+    m_instance = this;
+}
+
+BaseWorld::~BaseWorld()
+{
+    m_instance = 0;
+}
+
+LocatedEntity * BaseWorld::getEntity(const std::string & id) const
+{
+    return 0;
+}
+
+void Location::addToMessage(MapType & omap) const
+{
+}
+
+Location::Location() :
+        m_loc(0)
+{
+}
+
+void Location::addToEntity(const Atlas::Objects::Entity::RootEntity & ent) const
+{
+}
+void Location::modifyBBox()
+{
+}
+
+
+Inheritance::Inheritance() {}
+
+Inheritance & Inheritance::instance()
+{
+    return *(new Inheritance());
+}
+
+const TypeNode * Inheritance::getType(const std::string & parent)
+{
+    auto I = types.find(parent);
+    if (I == types.end()) {
+        return 0;
+    }
+    return I->second;
+}
+
+void log(LogLevel lvl, const std::string & msg)
+{
+}

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -69,7 +69,7 @@ class ProvidersTest : public Cyphesis::TestBase {
         void test_BBoxProviders();
         ///\Test Outfit providers
         void test_OutfitProviders();
-        ///\Test comparator predicates
+        ///\Test comparator and logical predicates
         void test_ComparePredicates();
 
 };
@@ -205,6 +205,18 @@ void ProvidersTest::test_ComparePredicates()
     ComparePredicate compPred8(lhs_provider2, new FixedElementProvider(48.0f),
                                ComparePredicate::Comparator::LESS_EQUAL);
     assert(compPred8.isMatch(QueryContext { *m_b1 }));
+
+    //entity.type = types.barrel && entity.bbox.volume = 48
+    AndPredicate andPred1(&compPred1, &compPred2);
+    assert(andPred1.isMatch(QueryContext { *m_b1 }));
+
+    //entity.type = types.barrel && entity.bbox.volume = 1
+    AndPredicate andPred2(&compPred1, &compPred3);
+    assert(!andPred2.isMatch(QueryContext { *m_b1 }));
+
+    //entity.type = types.barrel || entity.bbox.volume = 1
+    OrPredicate orPred1(&compPred1, &compPred3);
+    assert(orPred1.isMatch(QueryContext { *m_b1 }));
 }
 
 ProvidersTest::ProvidersTest()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -71,6 +71,8 @@ class ProvidersTest : public Cyphesis::TestBase {
         void test_OutfitProviders();
         ///\Test comparator and logical predicates
         void test_ComparePredicates();
+        ///\Test comparators that work on lists
+        void test_ListComparators();
 
 };
 
@@ -221,12 +223,53 @@ void ProvidersTest::test_ComparePredicates()
     assert(orPred1.isMatch(QueryContext { *m_b1 }));
 }
 
+void ProvidersTest::test_ListComparators(){
+
+    //entity.float_list
+    auto lhs_provider3 = CreateProvider( { "entity", "float_list" });
+
+    //entity.float_list contains 20.0
+    ComparePredicate compPred9(lhs_provider3, new FixedElementProvider(20.0),
+                               ComparePredicate::Comparator::CONTAINS);
+    assert(compPred9.isMatch(QueryContext { *m_b1 }));
+
+    //20.0 in entity.float_list
+    ComparePredicate compPred13(new FixedElementProvider(20.0), lhs_provider3,
+                                ComparePredicate::Comparator::IN);
+    assert(compPred13.isMatch(QueryContext { *m_b1 }));
+
+    //entity.float_list contains 100.0
+    ComparePredicate compPred10(lhs_provider3, new FixedElementProvider(100.0),
+                                ComparePredicate::Comparator::CONTAINS);
+    assert(!compPred10.isMatch(QueryContext { *m_b1 }));
+
+    //100.0 in entity.float_list
+    ComparePredicate compPred14(new FixedElementProvider(100.0), lhs_provider3,
+                                ComparePredicate::Comparator::IN);
+    assert(!compPred14.isMatch(QueryContext { *m_b1 }));
+
+    //entity.string_list
+    auto lhs_provider4 = CreateProvider( { "entity", "string_list" });
+
+    //entity.string_list contains "foo"
+    ComparePredicate compPred11(lhs_provider4, new FixedElementProvider("foo"),
+                                ComparePredicate::Comparator::CONTAINS);
+    assert(compPred11.isMatch(QueryContext { *m_b1 }));
+
+    //entity.string_list contains "foobar"
+    ComparePredicate compPred12(lhs_provider4,
+                                new FixedElementProvider("foobar"),
+                                ComparePredicate::Comparator::CONTAINS);
+    assert(!compPred12.isMatch(QueryContext { *m_b1 }));
+}
+
 ProvidersTest::ProvidersTest()
 {
     ADD_TEST(ProvidersTest::test_EntityProperty);
     ADD_TEST(ProvidersTest::test_BBoxProviders);
     ADD_TEST(ProvidersTest::test_OutfitProviders);
     ADD_TEST(ProvidersTest::test_ComparePredicates);
+    ADD_TEST(ProvidersTest::test_ListComparators);
 }
 
 void ProvidersTest::setup()
@@ -239,6 +282,16 @@ void ProvidersTest::setup()
     m_b1->setProperty("mass", new SoftProperty(Element(30)));
     m_b1->setProperty("burn_speed", new SoftProperty(Element(0.3)));
     m_b1->setProperty("isVisible", new SoftProperty(Element(true)));
+
+    //List properties for testing list operators
+    SoftProperty* prop1 = new SoftProperty();
+    prop1->set(std::vector<Element> { 25.0, 20.0 });
+    m_b1->setProperty("float_list", prop1);
+
+    SoftProperty* list_prop2 = new SoftProperty();
+    list_prop2->set(std::vector<Element> { "foo", "bar" });
+    m_b1->setProperty("string_list", list_prop2);
+
 
     //Make a second barrel
     m_b2 = new Entity("2", 2);

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -31,11 +31,17 @@
 
 #include <cassert>
 
+using namespace EntityFilter;
+using Atlas::Message::Element;
+
 static std::map<std::string, TypeNode*> types;
 
 class ProvidersTest : public Cyphesis::TestBase {
     private:
+        ProviderFactory m_factory;
 
+
+        Consumer<QueryContext>* CreateProvider(std::initializer_list<std::string> tokens);
     public:
         ProvidersTest();
 
@@ -59,17 +65,26 @@ void ProvidersTest::teardown()
 
 }
 
+Consumer<QueryContext>* ProvidersTest::CreateProvider(std::initializer_list<std::string> tokens){
+    ProviderFactory::SegmentsList segments;
+    auto iter = tokens.begin();
+
+    segments.push_back(ProviderFactory::Segment { "", *iter++});
+    for (; iter != tokens.end(); iter++){
+        segments.push_back(ProviderFactory::Segment { ".", *iter});
+    }
+    return m_factory.createProviders(segments);
+}
 
 
-int main(){
+int main()
+{
     ProvidersTest t;
 
     t.run();
 }
 
-
 //Stubs
-
 
 #include "stubs/common/stubVariable.h"
 #include "stubs/common/stubMonitors.h"

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -53,6 +53,7 @@ class ProvidersTest : public Cyphesis::TestBase {
         void setup();
         void teardown();
         void test_EntityProperty();
+        void test_BBoxProviders();
 
 };
 
@@ -87,9 +88,35 @@ void ProvidersTest::test_EntityProperty()
     assert(value.Float() == 0.3);
 }
 
+void ProvidersTest::test_BBoxProviders()
+{
+    Atlas::Message::Element value;
+
+    auto provider = CreateProvider( { "entity", "BBox", "Volume" });
+    provider->value(value, QueryContext { *m_b1 });
+    ASSERT_TRUE(value.Float() == 48.0);
+
+    provider = CreateProvider( { "entity", "BBox", "Height" });
+    provider->value(value, QueryContext { *m_b1 });
+    ASSERT_TRUE(value.Float() == 6.0);
+
+    provider = CreateProvider( { "entity", "BBox", "Width" });
+    provider->value(value, QueryContext { *m_b1 });
+    ASSERT_TRUE(value.Float() == 2.0);
+
+    provider = CreateProvider( { "entity", "BBox", "Depth" });
+    provider->value(value, QueryContext { *m_b1 });
+    ASSERT_TRUE(value.Float() == 4.0);
+
+    provider = CreateProvider( { "entity", "BBox", "Area" });
+    provider->value(value, QueryContext { *m_b1 });
+    ASSERT_TRUE(value.Float() == 8.0);
+}
+
 ProvidersTest::ProvidersTest()
 {
     ADD_TEST(ProvidersTest::test_EntityProperty);
+    ADD_TEST(ProvidersTest::test_BBoxProviders);
 }
 
 void ProvidersTest::setup()
@@ -115,7 +142,14 @@ void ProvidersTest::setup()
     m_b1_container->insert(m_b2);
     m_b1->m_contains = m_b1_container;
 
+    //Set bounding box properties for barrels
+    BBoxProperty* bbox1 = new BBoxProperty;
+    bbox1->set((std::vector<Element> { -1, -2, -3, 1, 2, 3 }));
+    m_b1->setProperty("bbox", bbox1);
 
+    BBoxProperty* bbox2 = new BBoxProperty;
+    bbox2->set(std::vector<Element> { -3, -1, -2, 1, 2, 3 });
+    m_b1->setProperty("bbox", bbox2);
 }
 
 void ProvidersTest::teardown()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -167,7 +167,9 @@ void ProvidersTest::setup()
 
 void ProvidersTest::teardown()
 {
-
+    delete m_b1;
+    delete m_b2;
+    delete m_barrelType;
 }
 
 Consumer<QueryContext>* ProvidersTest::CreateProvider(std::initializer_list<

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -1,0 +1,38 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#ifndef DEBUG
+#define DEBUG
+#endif
+
+#include "TestBase.h"
+
+
+
+class ProvidersTest : public Cyphesis::TestBase
+{
+  private:
+
+  public:
+    ProvidersTest();
+
+    void setup();
+    void teardown();
+
+};
+
+ProvidersTest::ProvidersTest()
+{
+
+}
+
+void ProvidersTest::setup()
+{
+
+}
+
+void ProvidersTest::teardown()
+{
+
+}
+

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -106,55 +106,54 @@ void ProvidersTest::test_EntityProperty()
 void ProvidersTest::test_BBoxProviders()
 {
     Atlas::Message::Element value;
-
     //entity.bbox.volume
-    auto provider = CreateProvider( { "entity", "BBox", "Volume" });
+    auto provider = CreateProvider( { "entity", "bbox", "volume" });
     provider->value(value, QueryContext { *m_b1 });
-    ASSERT_TRUE(value.Float() == 48.0);
+    assert(value.Float() == 48.0);
 
     //entity.bbox.height
-    provider = CreateProvider( { "entity", "BBox", "Height" });
+    provider = CreateProvider( { "entity", "bbox", "height" });
     provider->value(value, QueryContext { *m_b1 });
-    ASSERT_TRUE(value.Float() == 6.0);
+    assert(value.Float() == 6.0);
 
     //entity.bbox.width
-    provider = CreateProvider( { "entity", "BBox", "Width" });
+    provider = CreateProvider( { "entity", "bbox", "width" });
     provider->value(value, QueryContext { *m_b1 });
-    ASSERT_TRUE(value.Float() == 2.0);
+    assert(value.Float() == 2.0);
 
     //entity.bbox.depth
-    provider = CreateProvider( { "entity", "BBox", "Depth" });
+    provider = CreateProvider( { "entity", "bbox", "depth" });
     provider->value(value, QueryContext { *m_b1 });
-    ASSERT_TRUE(value.Float() == 4.0);
+    assert(value.Float() == 4.0);
 
     //entity.bbox.area
-    provider = CreateProvider( { "entity", "BBox", "Area" });
+    provider = CreateProvider( { "entity", "bbox", "area" });
     provider->value(value, QueryContext { *m_b1 });
-    ASSERT_TRUE(value.Float() == 8.0);
+    assert(value.Float() == 8.0);
 }
 
 void ProvidersTest::test_OutfitProviders()
 {
     Atlas::Message::Element value;
-    //Check simple outfit query
+    //Check if we get the right entity in outfit query
     auto provider = CreateProvider({"entity", "outfit", "hands"});
-    provider->value(value, QueryContext{*m_b1});
-    ASSERT_EQUAL(value.Ptr(), m_glovesEntity);
+    provider->value(value, QueryContext{*m_ch1});
+    ASSERT_EQUAL(*(Entity**)value.Ptr(), m_glovesEntity);
 
     //Check for outfit's property query
     provider = CreateProvider({"entity", "outfit", "hands", "color"});
-    provider->value(value, QueryContext{*m_b1});
-    ASSERT_EQUAL(value.String(), "brown");
+    provider->value(value, QueryContext{*m_ch1});
+    assert(value.String() == "brown");
 
-    //Check for nested outfit
+    //Check if we get the right entity in nested outfit query
     provider = CreateProvider({"entity", "outfit", "hands", "outfit", "thumb"});
-    provider->value(value, QueryContext{*m_b1});
-    ASSERT_EQUAL(value.Ptr(), m_cloth);
+    provider->value(value, QueryContext{*m_ch1});
+    assert(*(Entity**)value.Ptr() == m_cloth);
 
     //Check for nested outfit's property
     provider = CreateProvider({"entity", "outfit", "hands", "outfit", "thumb", "color"});
-    provider->value(value, QueryContext{*m_b1});
-    ASSERT_EQUAL(value.String(), "green");
+    provider->value(value, QueryContext{*m_ch1});
+    assert(value.String() == "green");
 }
 
 ProvidersTest::ProvidersTest()
@@ -195,7 +194,7 @@ void ProvidersTest::setup()
 
     BBoxProperty* bbox2 = new BBoxProperty;
     bbox2->set(std::vector<Element> { -3, -1, -2, 1, 2, 3 });
-    m_b1->setProperty("bbox", bbox2);
+    m_b2->setProperty("bbox", bbox2);
 
     ///Set up outfit testing
 
@@ -227,6 +226,7 @@ void ProvidersTest::setup()
     types["character"] = m_characterType;
     m_ch1 = new Entity("5", 5);
     m_ch1->setType(m_characterType);
+    m_ch1->setProperty("outfit", outfit1);
 }
 
 void ProvidersTest::teardown()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -7,17 +7,14 @@
 
 #include "TestBase.h"
 
+class ProvidersTest : public Cyphesis::TestBase {
+    private:
 
+    public:
+        ProvidersTest();
 
-class ProvidersTest : public Cyphesis::TestBase
-{
-  private:
-
-  public:
-    ProvidersTest();
-
-    void setup();
-    void teardown();
+        void setup();
+        void teardown();
 
 };
 

--- a/tests/EntityFiltertest.cpp
+++ b/tests/EntityFiltertest.cpp
@@ -429,10 +429,10 @@ EntityFilterTest::EntityFilterTest()
 int main()
 {
     EntityFilterTest t;
+
     t.run();
 
-    using namespace EntityFilter;
-
+    //TODO: Move remaining old tests
 // START of Soft property and general filtering tests
     /*{
      // test entity.attribute case with various operators
@@ -441,120 +441,6 @@ int main()
 
      {
      ProviderFactory factory;
-
-     //entity.type = types.barrel
-     ComparePredicate compPred1(lhs_provider1, rhs_provider1,
-     ComparePredicate::Comparator::INSTANCE_OF);
-     assert(compPred1.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume
-     segments.clear();
-     segments.push_back(ProviderFactory::Segment { "", "entity" });
-     segments.push_back(ProviderFactory::Segment { ".", "bbox" });
-     segments.push_back(ProviderFactory::Segment { ".", "volume" });
-     auto lhs_provider2 = factory.createProviders(segments);
-
-     //entity.bbox.volume = 48
-     ComparePredicate compPred2(lhs_provider2,
-     new FixedElementProvider(48.0f),
-     ComparePredicate::Comparator::EQUALS);
-     assert(compPred2.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume = 1
-     ComparePredicate compPred3(lhs_provider2,
-     new FixedElementProvider(1.0f),
-     ComparePredicate::Comparator::EQUALS);
-     assert(!compPred3.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume != 1
-     ComparePredicate compPred4(lhs_provider2,
-     new FixedElementProvider(1.0f),
-     ComparePredicate::Comparator::NOT_EQUALS);
-     assert(compPred4.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume > 0
-     ComparePredicate compPred5(lhs_provider2,
-     new FixedElementProvider(0.0f),
-     ComparePredicate::Comparator::GREATER);
-     assert(compPred5.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume >= 1
-     ComparePredicate compPred6(lhs_provider2,
-     new FixedElementProvider(1.0f),
-     ComparePredicate::Comparator::GREATER_EQUAL);
-     assert(compPred6.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume < 5
-     ComparePredicate compPred7(lhs_provider2,
-     new FixedElementProvider(5.0f),
-     ComparePredicate::Comparator::LESS);
-     assert(!compPred7.isMatch(QueryContext { b1 }));
-
-     //entity.bbox.volume <= 48
-     ComparePredicate compPred8(lhs_provider2,
-     new FixedElementProvider(48.0f),
-     ComparePredicate::Comparator::LESS_EQUAL);
-     assert(compPred8.isMatch(QueryContext { b1 }));
-
-     //entity.type = types.barrel && entity.bbox.volume = 48
-     AndPredicate andPred1(&compPred1, &compPred2);
-     assert(andPred1.isMatch(QueryContext { b1 }));
-
-     //entity.type = types.barrel && entity.bbox.volume = 1
-     AndPredicate andPred2(&compPred1, &compPred3);
-     assert(!andPred2.isMatch(QueryContext { b1 }));
-
-     //entity.type = types.barrel || entity.bbox.volume = 1
-     OrPredicate orPred1(&compPred1, &compPred3);
-     assert(orPred1.isMatch(QueryContext { b1 }));
-
-     //entity.float_list
-     segments.clear();
-     segments.push_back(ProviderFactory::Segment { "", "entity" });
-     segments.push_back(ProviderFactory::Segment { ".", "float_list" });
-     auto lhs_provider3 = factory.createProviders(segments);
-
-     //entity.float_list contains 20.0
-     ComparePredicate compPred9(lhs_provider3,
-     new FixedElementProvider(20.0),
-     ComparePredicate::Comparator::CONTAINS);
-     assert(compPred9.isMatch(QueryContext { bl1 }));
-
-     //20.0 in entity.float_list
-     ComparePredicate compPred13(new FixedElementProvider(20.0),
-     lhs_provider3,
-     ComparePredicate::Comparator::IN);
-     assert(compPred13.isMatch(QueryContext { bl1 }));
-
-     //entity.float_list contains 100.0
-     ComparePredicate compPred10(lhs_provider3,
-     new FixedElementProvider(100.0),
-     ComparePredicate::Comparator::CONTAINS);
-     assert(!compPred10.isMatch(QueryContext { bl1 }));
-
-     //100.0 in entity.float_list
-     ComparePredicate compPred14(new FixedElementProvider(100.0),
-     lhs_provider3,
-     ComparePredicate::Comparator::IN);
-     assert(!compPred14.isMatch(QueryContext { bl1 }));
-
-     //entity.string_list
-     segments.clear();
-     segments.push_back(ProviderFactory::Segment { "", "entity" });
-     segments.push_back(ProviderFactory::Segment { ".", "string_list" });
-     auto lhs_provider4 = factory.createProviders(segments);
-
-     //entity.string_list contains "foo"
-     ComparePredicate compPred11(lhs_provider4,
-     new FixedElementProvider("foo"),
-     ComparePredicate::Comparator::CONTAINS);
-     assert(compPred11.isMatch(QueryContext { bl1 }));
-
-     //entity.string_list contains "foobar"
-     ComparePredicate compPred12(lhs_provider4,
-     new FixedElementProvider("foobar"),
-     ComparePredicate::Comparator::CONTAINS);
-     assert(!compPred12.isMatch(QueryContext { bl1 }));
 
      //self.type
      segments.clear();
@@ -599,49 +485,7 @@ int main()
      ComparePredicate::Comparator::EQUALS);
      assert(compPred15.isMatch(QueryContext { b1, memory }));
 
-     //TESTS FOR contains_recursive FUNCTION
-     //entity.contains
-     segments.clear();
-     segments.push_back(ProviderFactory::Segment { "", "entity" });
-     segments.push_back(ProviderFactory::Segment { ".", "contains" });
-     auto lhs_provider7 = factory.createProviders(segments);
-
-     //types.boulder
-     segments.clear();
-     segments.push_back(ProviderFactory::Segment { "", "types" });
-     segments.push_back(ProviderFactory::Segment { ".", "boulder" });
-     auto rhs_provider = factory.createProviders(segments);
-
-     //lhs_provider1 = entity.type
-     ComparePredicate compPred17(lhs_provider1, rhs_provider,
-     ComparePredicate::Comparator::EQUALS);
-
-     ContainsRecursiveFunctionProvider contains_recursive(lhs_provider7,
-     &compPred17);
-     contains_recursive.value(value, QueryContext { b1 });
-     assert(value.Int() == 1);
-
-     contains_recursive.value(value, QueryContext { b2 });
-     assert(value.Int() == 0);
-
-     //rhs_provider1 = types.barrel
-     ComparePredicate compPred18(lhs_provider1, rhs_provider1,
-     ComparePredicate::Comparator::EQUALS);
-     ContainsRecursiveFunctionProvider contains_recursive2(lhs_provider7,
-     &compPred18);
-
-     contains_recursive2.value(value, QueryContext { b1 });
-     assert(value.Int() == 1);
-
-     contains_recursive2.value(value, QueryContext { bl1 });
-     assert(value.Int() == 1);
-
-     contains_recursive2.value(value, QueryContext { b2 });
-     assert(value.Int() == 0);
-
-     contains_recursive2.value(value, QueryContext { b3 });
-     assert(value.Int() == 0);
-     //END OF contains_recursive TESTS*/
+     */
 
 }
 

--- a/tests/EntityFiltertest.cpp
+++ b/tests/EntityFiltertest.cpp
@@ -497,11 +497,11 @@ void EntityFilterTest::TestQuery(const std::string& query,
     EntityFilter::Filter f(query, &factory);
     for (auto iter = entitiesToPass.begin(); iter != entitiesToPass.end();
             ++iter) {
-        ASSERT_TRUE(f.match(**iter));
+        assert(f.match(**iter));
     }
     for (auto iter = entitiesToFail.begin(); iter != entitiesToFail.end();
             ++iter) {
-        ASSERT_TRUE(!f.match(**iter));
+        assert(!f.match(**iter));
     }
 }
 

--- a/tests/EntityFiltertest.cpp
+++ b/tests/EntityFiltertest.cpp
@@ -6,6 +6,8 @@
 #endif
 
 //TODO: Check for unnecessary includes/links
+#include "TestBase.h"
+
 #include "rulesets/entityfilter/Filter.h"
 
 #include "rulesets/entityfilter/Providers.h"
@@ -34,65 +36,315 @@ using Atlas::Message::Element;
 using Atlas::Message::MapType;
 using Atlas::Objects::Entity::Anonymous;
 
+using namespace EntityFilter;
+
 static std::map<std::string, TypeNode*> types;
 
+class EntityFilterTest : public Cyphesis::TestBase {
 
-//\brief a tester function for entity filter. Accepts a query and lists of entities that
-// are supposed to pass or fail the test for a given query
-void TestQuery(const std::string& query,
-               std::initializer_list<Entity*> entitiesToPass,
-               std::initializer_list<Entity*> entitiesToFail)
+    private:
+        ProviderFactory m_factory;
+
+        //Entities for testing
+
+        //Barrels
+        Entity *m_b1;
+        Entity *m_b2;
+        Entity *m_b3;
+        LocatedEntitySet *m_b1_container; //Container property for b1
+
+        //Boulder
+        Entity *m_bl1;
+        LocatedEntitySet* m_bl1_container;
+
+        Entity *m_ch1; //Character entity
+        //Outfit for the character
+        Entity *m_glovesEntity; //Gloves for the character entity's outfit
+        Entity *m_bootsEntity;
+        Entity *m_cloth; //Cloth for gloves' outfit
+        Entity *m_leather;
+
+        //Types for testing
+        TypeNode *m_barrelType;
+        TypeNode* m_boulderType;
+        TypeNode *m_characterType;
+        TypeNode *m_clothType;
+        TypeNode* m_glovesType;
+        TypeNode* m_bootsType;
+
+        //\brief a tester function for entity filter. Accepts a query and lists of entities that
+        // are supposed to pass or fail the test for a given query
+        void TestQuery(const std::string& query,
+                       std::initializer_list<Entity*> entitiesToPass,
+                       std::initializer_list<Entity*> entitiesToFail);
+
+    public:
+        EntityFilterTest();
+        ///\Initialize private variables for testing before each test.
+        void setup();
+        ///\Free allocated space after every test
+        void teardown();
+
+        //General tests for soft properties. Also includes a few misc. tests
+        void test_SoftProperty();
+
+        //Test logical operators and precedence
+        void test_LogicalOperators();
+
+        //Test queries with parentheses
+        void test_Parentheses();
+
+        //Test outfit queries
+        void test_Outfit();
+
+        //Test BBox queries (such as volume and other dimensions)
+        void test_BBox();
+
+        //Test contains_recursive function
+        void test_ContainsRecursive();
+
+};
+
+void EntityFilterTest::test_SoftProperty()
 {
-    EntityFilter::ProviderFactory factory;
-    EntityFilter::Filter f(query, &factory);
-    for (auto iter = entitiesToPass.begin(); iter != entitiesToPass.end();
-            ++iter) {
-        assert(f.match(**iter));
+    TestQuery("entity.burn_speed=0.3", { m_b1 }, { m_b2 });
+
+    TestQuery("entity.burn_speed>0.3", { }, { m_b1, m_bl1 });
+    TestQuery("entity.burn_speed>=0.3", { m_b1 }, { m_bl1 });
+
+    TestQuery("entity.burn_speed<0.3", { m_b2 }, { m_b1 });
+    TestQuery("entity.burn_speed<=0.3", { m_b2, m_b1 }, { });
+
+    //test bool values
+    TestQuery("entity.isVisible = True", { m_b1 }, { m_b2 });
+    TestQuery("entity.isVisible = true", { m_b1 }, { m_b2 });
+
+    TestQuery("entity.isVisible = False", { m_b2 }, { m_b1 });
+    TestQuery("entity.isVisible = false", { m_b2 }, { m_b1 });
+
+    //test entity ID matching
+    TestQuery("entity.id=1", { m_b1 }, { m_b2 });
+
+    //test list match using "contains" operator
+
+    TestQuery("entity.float_list contains 20.0", { m_bl1 }, { });
+
+    TestQuery("entity.string_list contains 'foo'", { m_bl1 }, { });
+
+    TestQuery("entity.float_list contains 95.0", { }, { m_bl1 });
+
+    //test list match using "in" operator
+    TestQuery("20.0 in entity.float_list", { m_bl1 }, { });
+
+    //test queries with [] list notation
+    TestQuery("25 in [25, 30]", { m_bl1 }, { });
+
+    TestQuery("'foo' in ['bar']", { }, { m_bl1 });
+
+    TestQuery("entity.mass in [25, 30]", { m_b1 }, { m_b2 });
+
+    TestQuery("entity.burn_speed in [0.30, 0.40, 0.10]", { m_b1 }, { m_b2 });
+
+    //test query with several criteria
+
+    TestQuery("entity.type=types.barrel&&entity.burn_speed=0.3", { m_b1 }, {
+                      m_b2, m_bl1 });
+    //Test with fudged syntax
+    TestQuery("entity.type = types.barrel && entity.burn_speed = 0.3", { m_b1 },
+              { m_b2, m_bl1 });
+    TestQuery("entity.type  =  types.barrel  &&  entity.burn_speed  =  0.3", {
+                      m_b1 },
+              { m_b2, m_bl1 });
+
+    TestQuery("entity.type instance_of types.barrel", { m_b1 }, { m_bl1 });
+
+    //test query with spaces
+    TestQuery("  entity.type = types.barrel   ", { m_b1 }, { m_bl1 });
+
+    try {
+        TestQuery("foobar", { }, { m_b1, m_bl1 });
+        assert(false);
+    } catch (std::invalid_argument& e) {
     }
-    for (auto iter = entitiesToFail.begin(); iter != entitiesToFail.end();
-            ++iter) {
-        assert(!f.match(**iter));
+
+    //test a non-existing type
+    try {
+        TestQuery("entity.type instance_of types.foo", { }, { });
+        assert(false);
+    } catch (std::invalid_argument& e) {
+    }
+
+    //test invalid syntax
+    try {
+        TestQuery("entity.type instance_of | types.foo", { }, { });
+        assert(false);
+    } catch (std::invalid_argument& e) {
+    }
+    try {
+        TestQuery("entity,type = types.barrel", { }, { });
+        assert(false);
+    } catch (std::invalid_argument& e) {
     }
 }
-int main()
+
+void EntityFilterTest::test_LogicalOperators()
 {
-    using namespace EntityFilter;
+    //test operators "and", "or"
+    TestQuery("(entity.type=types.barrel and entity.burn_speed=0.3)", { m_b1 },
+              { m_bl1 });
 
-    //Set up testing environment for Type/Soft properties
-    Entity b1("1", 1);
-    TypeNode* barrelType = new TypeNode("barrel");
-    types["barrel"] = barrelType;
-    b1.setType(barrelType);
-    b1.setProperty("mass", new SoftProperty(Element(30)));
-    b1.setProperty("burn_speed", new SoftProperty(Element(0.3)));
-    b1.setProperty("isVisible", new SoftProperty(Element(true)));
+    TestQuery("entity.type instance_of types.barrel   or   entity.mass=25", {
+                      m_b1, m_b2, m_bl1 },
+              { });
 
-    Entity b2("2", 2);
-    b2.setProperty("mass", new SoftProperty(Element(20)));
-    b2.setProperty("burn_speed", new SoftProperty(0.25));
-    b2.setType(barrelType);
-    b2.setProperty("isVisible", new SoftProperty(Element(false)));
+    //test multiple types for instance_of operator
+    TestQuery("entity.type instance_of types.barrel|types.boulder", { m_b1,
+                      m_bl1 },
+              { });
 
-    Entity b3("3", 3);
-    b3.setProperty("mass", new SoftProperty(Element(25)));
-    b3.setProperty("burn_speed", new SoftProperty(Element(0.25)));
-    b3.setType(barrelType);
+    //test and operator without spaces
+    try {
+        TestQuery("entity.type=types.barrelandentity.burn_speed=0.3", { }, { });
+        assert(false);
+    } catch (std::invalid_argument& e) {
+    }
 
-    TypeNode* boulderType = new TypeNode("boulder");
-    types["boulder"] = boulderType;
-    Entity bl1("4", 4);
-    bl1.setProperty("mass", new SoftProperty(Element(25)));
-    bl1.setType(boulderType);
+    //test logical operators and precedence
+
+    TestQuery("entity.type=types.barrel||entity.type=types.boulder", { m_b1,
+                      m_bl1 },
+              { });
+
+    TestQuery(
+            "entity.type=types.boulder||entity.type=types.barrel&&entity.burn_speed=0.3",
+            { m_b1, m_bl1 }, { });
+
+}
+
+void EntityFilterTest::test_Parentheses()
+{
+
+    //test query with parenthesis
+    TestQuery("(entity.type=types.boulder)", { m_bl1 }, { m_b1 });
+
+    TestQuery("(entity.type=types.boulder)&&(entity.mass=25)", { m_bl1 },
+              { m_b1 });
+
+    //test query with nested parentheses
+    TestQuery(
+            "(entity.type=types.barrel&&(entity.mass=25||entity.mass=30)||entity.type=types.boulder)",
+            { m_b1, m_b3, m_bl1 }, { m_b2 });
+    //Test with fudged syntax
+    TestQuery(
+            "(entity.type = types.barrel && ( entity.mass = 25 || entity.mass = 30 ) || entity.type = types.boulder )",
+            { m_b1, m_b3, m_bl1 }, { m_b2 });
+
+    TestQuery(
+            "(entity.type=types.barrel&&(entity.mass=25&&(entity.burn_speed=0.25||entity.mass=30))||entity.type=types.boulder)",
+            { m_bl1 }, { m_b1 });
+
+    //override precedence rules with parentheses
+    TestQuery(
+            "(entity.type=types.boulder||entity.type=types.barrel)&&entity.burn_speed=0.3",
+            { m_b1 }, { m_bl1 });
+}
+
+void EntityFilterTest::test_Outfit()
+{
+    //Test soft property of outfit
+    TestQuery("entity.outfit.hands.color='brown'", { m_ch1 }, { });
+    //Test type of outfit
+    TestQuery("entity.outfit.hands.type=types.gloves", { m_ch1 }, { });
+    //Test an entity without outfit
+    TestQuery("entity.outfit.hands.type=types.gloves", { }, { m_bl1 });
+    //Test outfit that doesn't have the specified part
+    TestQuery("entity.outfit.chest.color='red'", { }, { m_ch1 });
+    //Test outfit with another criterion
+    TestQuery("entity.type=types.character&&entity.outfit.hands.color='brown'",
+              { m_ch1 }, { m_b1 });
+    //Test nested outfit
+    TestQuery("entity.outfit.hands.outfit.thumb.color='green'", { m_ch1 }, { });
+
+    TestQuery("entity.outfit.hands.outfit.thumb.type=types.cloth", { m_ch1 },
+              { });
+
+    TestQuery("entity.type instance_of types.barrel|types.boulder|types.gloves",
+              { m_b1, m_bl1, m_glovesEntity }, { });
+}
+
+void EntityFilterTest::test_BBox()
+{
+    //Test BBox volume
+    TestQuery("entity.bbox.volume=48.0", { m_b1 }, { m_bl1 });
+    //Test BBox height
+    TestQuery("entity.bbox.height=6.0", { m_b1 }, { m_bl1 });
+    //Test BBox length
+    TestQuery("entity.bbox.depth=4.0", { m_b1 }, { m_bl1 });
+    //Test BBox width
+    TestQuery("entity.bbox.width=2.0", { m_b1 }, { m_bl1 });
+    //Test BBox area
+    TestQuery("entity.bbox.area=8.0", { m_b1 }, { m_bl1 });
+    //Test BBox with another criterion
+    TestQuery("entity.type=types.barrel&&entity.bbox.height>0.0", { m_b1 }, {
+                      m_b2, m_bl1 });
+    //Test BBox of an outfit
+    TestQuery("entity.outfit.hands.outfit.thumb.bbox.volume=48.0", { m_ch1 },
+              { });
+}
+
+void EntityFilterTest::test_ContainsRecursive()
+{
+    //Test contains_recursive function
+    TestQuery(
+            "contains_recursive(entity.contains, entity.type=types.boulder) = True",
+            { m_b1 }, { m_b2 });
+
+    TestQuery(
+            "contains_recursive(entity.contains, entity.type=types.barrel) = True",
+            { m_b1, m_bl1 }, { m_b2 });
+
+    TestQuery(
+            "contains_recursive(entity.contains, entity.type=types.barrel or entity.mass = 25) = true",
+            { m_b1, m_bl1 }, { m_b2 });
+}
+
+void EntityFilterTest::setup()
+{
+//Set up testing environment for Type/Soft properties
+    m_b1 = new Entity("1", 1);
+    m_barrelType = new TypeNode("barrel");
+    types["barrel"] = m_barrelType;
+    m_b1->setType(m_barrelType);
+    m_b1->setProperty("mass", new SoftProperty(Element(30)));
+    m_b1->setProperty("burn_speed", new SoftProperty(Element(0.3)));
+    m_b1->setProperty("isVisible", new SoftProperty(Element(true)));
+
+    m_b2 = new Entity("2", 2);
+    m_b2->setProperty("mass", new SoftProperty(Element(20)));
+    m_b2->setProperty("burn_speed", new SoftProperty(0.25));
+    m_b2->setType(m_barrelType);
+    m_b2->setProperty("isVisible", new SoftProperty(Element(false)));
+
+    m_b3 = new Entity("3", 3);
+    m_b3->setProperty("mass", new SoftProperty(Element(25)));
+    m_b3->setProperty("burn_speed", new SoftProperty(Element(0.25)));
+    m_b3->setType(m_barrelType);
+
+    m_boulderType = new TypeNode("boulder");
+    types["boulder"] = m_boulderType;
+    m_bl1 = new Entity("4", 4);
+    m_bl1->setProperty("mass", new SoftProperty(Element(25)));
+    m_bl1->setType(m_boulderType);
 
     SoftProperty* prop1 = new SoftProperty();
-    prop1->set(std::vector<Element> {25.0, 20.0});
-    bl1.setProperty("float_list", prop1);
+    prop1->set(std::vector<Element> { 25.0, 20.0 });
+    m_bl1->setProperty("float_list", prop1);
 
     SoftProperty* list_prop2 = new SoftProperty();
-    list_prop2->set(std::vector<Element> {"foo", "bar"});
-    bl1.setProperty("string_list", list_prop2);
+    list_prop2->set(std::vector<Element> { "foo", "bar" });
+    m_bl1->setProperty("string_list", list_prop2);
 
-    // Create an entity-related memory map
+// Create an entity-related memory map
     std::map<std::string, Element> entity_memory_map;
     entity_memory_map.insert(std::make_pair("disposition", Element(25)));
     Element memory_map_element(entity_memory_map);
@@ -100,550 +352,336 @@ int main()
     std::map<std::string, Element> memory;
     memory.insert(std::make_pair("1", memory_map_element));
 
-    //b1 contains bl1 which contains b3
-    auto b1_container = new LocatedEntitySet;
-    b1_container->insert(&bl1);
-    b1.m_contains = b1_container;
+//b1 contains bl1 which contains b3
+    m_b1_container = new LocatedEntitySet;
+    m_b1_container->insert(m_bl1);
+    m_b1->m_contains = m_b1_container;
 
-    auto bl1_container = new LocatedEntitySet;
-    bl1_container->insert(&b3);
-    bl1.m_contains = bl1_container;
+    m_bl1_container = new LocatedEntitySet;
+    m_bl1_container->insert(m_b3);
+    m_bl1->m_contains = m_bl1_container;
 
+//Set up testing environment for Outfit property
+    m_glovesType = new TypeNode("gloves");
+    types["gloves"] = m_glovesType;
+    m_bootsType = new TypeNode("boots");
+    m_characterType = new TypeNode("character");
+    types["character"] = m_characterType;
+    TypeNode* m_clothType = new TypeNode("cloth");
+    types["cloth"] = m_clothType;
+    TypeNode* m_leatherType = new TypeNode("leather");
 
+    m_glovesEntity = new Entity("5", 5);
+    m_glovesEntity->setType(m_glovesType);
+    m_glovesEntity->setProperty("color", new SoftProperty("brown"));
+    m_glovesEntity->setProperty("mass", new SoftProperty(5));
 
-// START of Soft property and general filtering tests
-    {
-        TestQuery("entity.type instance_of types.barrel", { &b1 }, { &bl1 });
-        // test entity.attribute case with various operators
-        TestQuery("entity.burn_speed=0.3", { &b1 }, { &b2 });
-
-        TestQuery("entity.burn_speed>0.3", { }, { &b1, &bl1 });
-        TestQuery("entity.burn_speed>=0.3", { &b1 }, { &bl1 });
-
-        TestQuery("entity.burn_speed<0.3", { &b2 }, { &b1 });
-        TestQuery("entity.burn_speed<=0.3", { &b2, &b1 }, { });
-
-        //test bool values
-        TestQuery("entity.isVisible = True", {&b1}, {&b2});
-        TestQuery("entity.isVisible = true", {&b1}, {&b2});
-
-        TestQuery("entity.isVisible = False", {&b2}, {&b1});
-        TestQuery("entity.isVisible = false", {&b2}, {&b1});
-
-        //test entity ID matching
-        TestQuery("entity.id=1", {&b1}, {&b2});
-
-        //test list match using "contains" operator
-
-        TestQuery("entity.float_list contains 20.0", {&bl1}, {});
-
-        TestQuery("entity.string_list contains 'foo'", {&bl1}, {});
-
-        TestQuery("entity.float_list contains 95.0", {}, {&bl1});
-
-        //test list match using "in" operator
-        TestQuery("20.0 in entity.float_list", {&bl1}, {});
-
-        //test queries with [] list notation
-        TestQuery("25 in [25, 30]", {&bl1}, {});
-
-        TestQuery("'foo' in ['bar']", {}, {&bl1});
-
-        TestQuery("entity.mass in [25, 30]", {&b1}, {&b2});
-
-        TestQuery("entity.burn_speed in [0.30, 0.40, 0.10]", {&b1}, {&b2});
-
-        //test query with several criteria
-
-        TestQuery("entity.type=types.barrel&&entity.burn_speed=0.3", { &b1 }, { &b2,
-                          &bl1 });
-        //Test with fudged syntax
-        TestQuery("entity.type = types.barrel && entity.burn_speed = 0.3", { &b1 }, { &b2,
-                          &bl1 });
-        TestQuery("entity.type  =  types.barrel  &&  entity.burn_speed  =  0.3", { &b1 }, { &b2,
-                          &bl1 });
-
-        //test logical operators and precedence
-
-        TestQuery("entity.type=types.barrel||entity.type=types.boulder", { &b1, &bl1 }, { });
-
-        TestQuery(
-                "entity.type=types.boulder||entity.type=types.barrel&&entity.burn_speed=0.3",
-                { &b1, &bl1 }, { });
-
-        //test query with parenthesis
-        TestQuery("(entity.type=types.boulder)", {&bl1}, {&b1});
-
-        TestQuery("(entity.type=types.boulder)&&(entity.mass=25)", {&bl1}, {&b1});
-
-        //test query with nested parentheses
-        TestQuery("(entity.type=types.barrel&&(entity.mass=25||entity.mass=30)||entity.type=types.boulder)", {&b1, &b3, &bl1}, {&b2});
-        //Test with fudged syntax
-        TestQuery("(entity.type = types.barrel && ( entity.mass = 25 || entity.mass = 30 ) || entity.type = types.boulder )", {&b1, &b3, &bl1}, {&b2});
-
-        TestQuery("(entity.type=types.barrel&&(entity.mass=25&&(entity.burn_speed=0.25||entity.mass=30))||entity.type=types.boulder)", {&bl1}, {&b1});
-
-        //override precedence rules with parentheses
-        TestQuery("(entity.type=types.boulder||entity.type=types.barrel)&&entity.burn_speed=0.3", {&b1}, {&bl1});
-
-        //test operators "and", "or"
-        TestQuery("(entity.type=types.barrel and entity.burn_speed=0.3)", {&b1}, {&bl1});
-
-        TestQuery("entity.type instance_of types.barrel   or   entity.mass=25", {&b1, &b2, &bl1}, {});
-
-        //test multiple types for instance_of operator
-        TestQuery("entity.type instance_of types.barrel|types.boulder", {&b1, &bl1}, {});
-
-        //test and operator without spaces
-        try {
-            TestQuery("entity.type=types.barrelandentity.burn_speed=0.3", { }, { });
-            assert(false);
-        } catch (std::invalid_argument& e) {
-        }
-        //test query with spaces
-        TestQuery("  entity.type = types.barrel   ", { &b1 }, { &bl1 });
-
-        try {
-            TestQuery("foobar", { }, { &b1, &bl1 });
-            assert(false);
-        } catch (std::invalid_argument& e) {
-        }
-
-        //test a non-existing type
-        try{
-            TestQuery("entity.type instance_of types.foo", { }, { });
-            assert(false);
-        } catch (std::invalid_argument& e) {
-        }
-
-        //test invalid syntax
-        try{
-            TestQuery("entity.type instance_of | types.foo", { }, { });
-            assert(false);
-        } catch (std::invalid_argument& e) {}
-        try{
-            TestQuery("entity,type = types.barrel", { }, { });
-            assert(false);
-        } catch (std::invalid_argument& e) {}
-
-        //Test contains_recursive function
-        TestQuery("contains_recursive(entity.contains, entity.type=types.boulder) = True", { &b1 }, { &b2 });
-
-        TestQuery("contains_recursive(entity.contains, entity.type=types.barrel) = True", { &b1, &bl1 }, { &b2 });
-
-        TestQuery("contains_recursive(entity.contains, entity.type=types.barrel or entity.mass = 25) = true",
-                  { &b1, &bl1 }, { &b2 });
-        //Test a memory.* query
-//        Filter f("memory.disposition = 25");
-//        assert(f.match(QueryContext{b1, memory}));
-//        assert(!f.match(QueryContext{b2, memory}));
-    }
-    // END of soft property and general tests
-
-    //Set up testing environment for Outfit property
-    TypeNode* glovesType = new TypeNode("gloves");
-    types["gloves"] = glovesType;
-    TypeNode* bootsType = new TypeNode("boots");
-    TypeNode* characterType = new TypeNode("character");
-    types["character"] = characterType;
-    TypeNode* clothType = new TypeNode("cloth");
-    types["cloth"] = clothType;
-    TypeNode* leatherType = new TypeNode("leather");
-
-    Entity glovesEntity("5", 5);
-    glovesEntity.setType(glovesType);
-    glovesEntity.setProperty("color", new SoftProperty("brown"));
-    glovesEntity.setProperty("mass", new SoftProperty(5));
-
-    Entity bootsEntity("6", 6);
-    bootsEntity.setType(bootsType);
-    bootsEntity.setProperty("color", new SoftProperty("black"));
-    bootsEntity.setProperty("mass", new SoftProperty(10));
+    m_bootsEntity = new Entity("6", 6);
+    m_bootsEntity->setType(m_bootsType);
+    m_bootsEntity->setProperty("color", new SoftProperty("black"));
+    m_bootsEntity->setProperty("mass", new SoftProperty(10));
 
     std::map<std::string, Element> outfitMap;
-    outfitMap.insert(std::make_pair("feet", Element(&bootsEntity)));
-    outfitMap.insert(std::make_pair("hands", Element(&glovesEntity)));
+    outfitMap.insert(std::make_pair("feet", Element(m_bootsEntity)));
+    outfitMap.insert(std::make_pair("hands", Element(m_glovesEntity)));
     OutfitProperty* outfit1 = new OutfitProperty;
     outfit1->set(outfitMap);
 
-    Entity cloth("8", 8);
-    cloth.setType(clothType);
-    cloth.setProperty("color", new SoftProperty("green"));
+    m_cloth = new Entity("8", 8);
+    m_cloth->setType(m_clothType);
+    m_cloth->setProperty("color", new SoftProperty("green"));
 
-    Entity leather("9", 9);
-    leather.setType(leatherType);
-    leather.setProperty("color", new SoftProperty("pink"));
+    m_leather = new Entity("9", 9);
+    m_leather->setType(m_leatherType);
+    m_leather->setProperty("color", new SoftProperty("pink"));
 
     std::map<std::string, Element> outfitMap1;
-    outfitMap1.insert(std::make_pair("thumb", Element(&cloth)));
+    outfitMap1.insert(std::make_pair("thumb", Element(m_cloth)));
     OutfitProperty* outfit2 = new OutfitProperty;
     outfit2->set(outfitMap1);
-    glovesEntity.setProperty("outfit", outfit2);
+    m_glovesEntity->setProperty("outfit", outfit2);
 
-    Entity ch1("7", 7);
-    ch1.setType(characterType);
-    ch1.setProperty("outfit", outfit1);
-
-    //START of outfit case test
-    {
-        //Test soft property of outfit
-        TestQuery("entity.outfit.hands.color='brown'", { &ch1 }, { });
-        //Test type of outfit
-        TestQuery("entity.outfit.hands.type=types.gloves", { &ch1 }, { });
-        //Test an entity without outfit
-        TestQuery("entity.outfit.hands.type=types.gloves", { }, { &bl1 });
-        //Test outfit that doesn't have the specified part
-        TestQuery("entity.outfit.chest.color='red'", { }, { &ch1 });
-        //Test outfit with another criterion
-        TestQuery("entity.type=types.character&&entity.outfit.hands.color='brown'", { &ch1 },
-                  { &b1 });
-        //Test nested outfit
-        TestQuery("entity.outfit.hands.outfit.thumb.color='green'", {&ch1}, {});
-
-        TestQuery("entity.outfit.hands.outfit.thumb.type=types.cloth", {&ch1}, {});
-
-        TestQuery("entity.type instance_of types.barrel|types.boulder|types.gloves", {&b1, &bl1, &glovesEntity}, {});
-    }
-    //END of outfit case test
-
-//Set up bbox testing environment
+    m_ch1 = new Entity("7", 7);
+    m_ch1->setType(m_characterType);
+    m_ch1->setProperty("outfit", outfit1);
 
     BBoxProperty* bbox1 = new BBoxProperty;
     bbox1->set((std::vector<Element> { -1, -2, -3, 1, 2, 3 }));
-    b1.setProperty("bbox", bbox1);
+    m_b1->setProperty("bbox", bbox1);
 
     BBoxProperty* bbox2 = new BBoxProperty;
     bbox2->set(std::vector<Element> { -3, -1, -2, 1, 2, 3 });
-    bl1.setProperty("bbox", bbox2);
+    m_bl1->setProperty("bbox", bbox2);
 
-    cloth.setProperty("bbox", bbox1->copy());
-    //START of BBox tests
-    {
-        //Test BBox volume
-        TestQuery("entity.bbox.volume=48.0", { &b1 }, { &bl1 });
-        //Test BBox height
-        TestQuery("entity.bbox.height=6.0", { &b1 }, { &bl1 });
-        //Test BBox length
-        TestQuery("entity.bbox.depth=4.0", { &b1 }, { &bl1 });
-        //Test BBox width
-        TestQuery("entity.bbox.width=2.0", { &b1 }, { &bl1 });
-        //Test BBox area
-        TestQuery("entity.bbox.area=8.0", { &b1 }, { &bl1 });
-        //Test BBox with another criterion
-        TestQuery("entity.type=types.barrel&&entity.bbox.height>0.0", { &b1 }, { &b2,
-                          &bl1 });
-        //Test BBox of an outfit
-        TestQuery("entity.outfit.hands.outfit.thumb.bbox.volume=48.0", {&ch1}, {});
+    m_cloth->setProperty("bbox", bbox1->copy());
+}
+
+EntityFilterTest::EntityFilterTest()
+{
+    ADD_TEST(EntityFilterTest::test_SoftProperty);
+    ADD_TEST(EntityFilterTest::test_LogicalOperators);
+    ADD_TEST(EntityFilterTest::test_Parentheses);
+    ADD_TEST(EntityFilterTest::test_Outfit);
+    ADD_TEST(EntityFilterTest::test_BBox);
+    ADD_TEST(EntityFilterTest::test_ContainsRecursive);
+}
+
+int main()
+{
+    EntityFilterTest t;
+    t.run();
+
+    using namespace EntityFilter;
+
+// START of Soft property and general filtering tests
+    /*{
+     // test entity.attribute case with various operators
+
+     // END of soft property and general tests
+
+     {
+     ProviderFactory factory;
+
+     //entity.type = types.barrel
+     ComparePredicate compPred1(lhs_provider1, rhs_provider1,
+     ComparePredicate::Comparator::INSTANCE_OF);
+     assert(compPred1.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "entity" });
+     segments.push_back(ProviderFactory::Segment { ".", "bbox" });
+     segments.push_back(ProviderFactory::Segment { ".", "volume" });
+     auto lhs_provider2 = factory.createProviders(segments);
+
+     //entity.bbox.volume = 48
+     ComparePredicate compPred2(lhs_provider2,
+     new FixedElementProvider(48.0f),
+     ComparePredicate::Comparator::EQUALS);
+     assert(compPred2.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume = 1
+     ComparePredicate compPred3(lhs_provider2,
+     new FixedElementProvider(1.0f),
+     ComparePredicate::Comparator::EQUALS);
+     assert(!compPred3.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume != 1
+     ComparePredicate compPred4(lhs_provider2,
+     new FixedElementProvider(1.0f),
+     ComparePredicate::Comparator::NOT_EQUALS);
+     assert(compPred4.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume > 0
+     ComparePredicate compPred5(lhs_provider2,
+     new FixedElementProvider(0.0f),
+     ComparePredicate::Comparator::GREATER);
+     assert(compPred5.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume >= 1
+     ComparePredicate compPred6(lhs_provider2,
+     new FixedElementProvider(1.0f),
+     ComparePredicate::Comparator::GREATER_EQUAL);
+     assert(compPred6.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume < 5
+     ComparePredicate compPred7(lhs_provider2,
+     new FixedElementProvider(5.0f),
+     ComparePredicate::Comparator::LESS);
+     assert(!compPred7.isMatch(QueryContext { b1 }));
+
+     //entity.bbox.volume <= 48
+     ComparePredicate compPred8(lhs_provider2,
+     new FixedElementProvider(48.0f),
+     ComparePredicate::Comparator::LESS_EQUAL);
+     assert(compPred8.isMatch(QueryContext { b1 }));
+
+     //entity.type = types.barrel && entity.bbox.volume = 48
+     AndPredicate andPred1(&compPred1, &compPred2);
+     assert(andPred1.isMatch(QueryContext { b1 }));
+
+     //entity.type = types.barrel && entity.bbox.volume = 1
+     AndPredicate andPred2(&compPred1, &compPred3);
+     assert(!andPred2.isMatch(QueryContext { b1 }));
+
+     //entity.type = types.barrel || entity.bbox.volume = 1
+     OrPredicate orPred1(&compPred1, &compPred3);
+     assert(orPred1.isMatch(QueryContext { b1 }));
+
+     //entity.float_list
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "entity" });
+     segments.push_back(ProviderFactory::Segment { ".", "float_list" });
+     auto lhs_provider3 = factory.createProviders(segments);
+
+     //entity.float_list contains 20.0
+     ComparePredicate compPred9(lhs_provider3,
+     new FixedElementProvider(20.0),
+     ComparePredicate::Comparator::CONTAINS);
+     assert(compPred9.isMatch(QueryContext { bl1 }));
+
+     //20.0 in entity.float_list
+     ComparePredicate compPred13(new FixedElementProvider(20.0),
+     lhs_provider3,
+     ComparePredicate::Comparator::IN);
+     assert(compPred13.isMatch(QueryContext { bl1 }));
+
+     //entity.float_list contains 100.0
+     ComparePredicate compPred10(lhs_provider3,
+     new FixedElementProvider(100.0),
+     ComparePredicate::Comparator::CONTAINS);
+     assert(!compPred10.isMatch(QueryContext { bl1 }));
+
+     //100.0 in entity.float_list
+     ComparePredicate compPred14(new FixedElementProvider(100.0),
+     lhs_provider3,
+     ComparePredicate::Comparator::IN);
+     assert(!compPred14.isMatch(QueryContext { bl1 }));
+
+     //entity.string_list
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "entity" });
+     segments.push_back(ProviderFactory::Segment { ".", "string_list" });
+     auto lhs_provider4 = factory.createProviders(segments);
+
+     //entity.string_list contains "foo"
+     ComparePredicate compPred11(lhs_provider4,
+     new FixedElementProvider("foo"),
+     ComparePredicate::Comparator::CONTAINS);
+     assert(compPred11.isMatch(QueryContext { bl1 }));
+
+     //entity.string_list contains "foobar"
+     ComparePredicate compPred12(lhs_provider4,
+     new FixedElementProvider("foobar"),
+     ComparePredicate::Comparator::CONTAINS);
+     assert(!compPred12.isMatch(QueryContext { bl1 }));
+
+     //self.type
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "self" });
+     segments.push_back(ProviderFactory::Segment { ".", "mass" });
+     auto lhs_provider5 = factory.createProviders(segments);
+     QueryContext qc { bl1 };
+     qc.self_entity = &b1;
+
+     lhs_provider5->value(value, qc);
+     assert(value == Element(30));
+
+     //MindProviderFactory tests
+     MindProviderFactory mind_factory;
+
+     //memory.disposition
+     segments.clear();
+     segments.push_back( { "", "memory" });
+     segments.push_back( { ".", "disposition" });
+     provider = mind_factory.createProviders(segments);
+     provider->value(value, QueryContext { b1, memory });
+     assert(value.Int() == 25);
+
+     //entity.memory
+     segments.clear();
+     segments.push_back( { "", "memory" });
+     segments.push_back( { ".", "disposition" });
+     lhs_provider5 = mind_factory.createProviders(segments);
+
+     ComparePredicate compPred15(lhs_provider5, new FixedElementProvider(25),
+     ComparePredicate::Comparator::EQUALS);
+     assert(compPred15.isMatch(QueryContext { b1, memory }));
+
+     //entity.type.name
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "entity" });
+     segments.push_back(ProviderFactory::Segment { ".", "type" });
+     segments.push_back(ProviderFactory::Segment { ".", "name" });
+     auto lhs_provider6 = mind_factory.createProviders(segments);
+     ComparePredicate compPred16(lhs_provider6,
+     new FixedElementProvider("barrel"),
+     ComparePredicate::Comparator::EQUALS);
+     assert(compPred15.isMatch(QueryContext { b1, memory }));
+
+     //TESTS FOR contains_recursive FUNCTION
+     //entity.contains
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "entity" });
+     segments.push_back(ProviderFactory::Segment { ".", "contains" });
+     auto lhs_provider7 = factory.createProviders(segments);
+
+     //types.boulder
+     segments.clear();
+     segments.push_back(ProviderFactory::Segment { "", "types" });
+     segments.push_back(ProviderFactory::Segment { ".", "boulder" });
+     auto rhs_provider = factory.createProviders(segments);
+
+     //lhs_provider1 = entity.type
+     ComparePredicate compPred17(lhs_provider1, rhs_provider,
+     ComparePredicate::Comparator::EQUALS);
+
+     ContainsRecursiveFunctionProvider contains_recursive(lhs_provider7,
+     &compPred17);
+     contains_recursive.value(value, QueryContext { b1 });
+     assert(value.Int() == 1);
+
+     contains_recursive.value(value, QueryContext { b2 });
+     assert(value.Int() == 0);
+
+     //rhs_provider1 = types.barrel
+     ComparePredicate compPred18(lhs_provider1, rhs_provider1,
+     ComparePredicate::Comparator::EQUALS);
+     ContainsRecursiveFunctionProvider contains_recursive2(lhs_provider7,
+     &compPred18);
+
+     contains_recursive2.value(value, QueryContext { b1 });
+     assert(value.Int() == 1);
+
+     contains_recursive2.value(value, QueryContext { bl1 });
+     assert(value.Int() == 1);
+
+     contains_recursive2.value(value, QueryContext { b2 });
+     assert(value.Int() == 0);
+
+     contains_recursive2.value(value, QueryContext { b3 });
+     assert(value.Int() == 0);
+     //END OF contains_recursive TESTS*/
+
+}
+
+void EntityFilterTest::TestQuery(const std::string& query,
+                                 std::initializer_list<Entity*> entitiesToPass,
+                                 std::initializer_list<Entity*> entitiesToFail)
+{
+    EntityFilter::ProviderFactory factory;
+    EntityFilter::Filter f(query, &factory);
+    for (auto iter = entitiesToPass.begin(); iter != entitiesToPass.end();
+            ++iter) {
+        ASSERT_TRUE(f.match(**iter));
     }
-    //END of BBox tests
-
-
-    {
-        ProviderFactory factory;
-
-        //entity
-        Atlas::Message::Element value;
-        ProviderFactory::SegmentsList segments;
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        auto provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.Ptr() == &b1);
-
-        //entity.type
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "type"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.Ptr() == barrelType);
-
-        //entity.id
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "id"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.Int() == 1);
-
-        //entity.mass
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "mass"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.Int() == 30);
-
-
-
-
-        //entity.outfit.hands.color
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "outfit"});
-        segments.push_back(ProviderFactory::Segment{".", "hands"});
-        segments.push_back(ProviderFactory::Segment{".", "color"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{ch1});
-        assert(value.String() == "brown");
-
-
-
-        //entity.bbox.volume
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "bbox"});
-        segments.push_back(ProviderFactory::Segment{".", "volume"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.asNum() == 48);
-
-
-
-        //entity.right_hand_wield.color
-        EntityProperty* wield_prop = new EntityProperty();
-        wield_prop->data() = EntityRef(&glovesEntity);
-        ch1.setProperty("right_hand_wield", wield_prop);
-
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "right_hand_wield"});
-        segments.push_back(ProviderFactory::Segment{".", "color"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{ch1});
-        assert(value.String() == "brown");
-
-
-
-        //types.barrel
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "types"});
-        segments.push_back(ProviderFactory::Segment{".", "barrel"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{ch1});
-        assert(value.Ptr() == barrelType);
-
-
-        //types.barrel.name
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "types"});
-        segments.push_back(ProviderFactory::Segment{".", "barrel"});
-        segments.push_back(ProviderFactory::Segment{".", "name"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{ch1});
-        assert(value.String() == "barrel");
-
-        //entity.contains
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "contains"});
-        provider = factory.createProviders(segments);
-        provider->value(value, QueryContext{b1});
-        assert(value.Ptr() == b1_container);
-
-
-
-
-
-
-
-
-
-        //entity.type
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "type"});
-        auto lhs_provider1 = factory.createProviders(segments);
-
-
-        //types.barrel
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "types"});
-        segments.push_back(ProviderFactory::Segment{".", "barrel"});
-        auto rhs_provider1 = factory.createProviders(segments);
-
-        //entity.type = types.barrel
-        ComparePredicate compPred1(lhs_provider1, rhs_provider1, ComparePredicate::Comparator::INSTANCE_OF);
-        assert(compPred1.isMatch(QueryContext{b1}));
-
-
-
-
-
-        //entity.bbox.volume
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "bbox"});
-        segments.push_back(ProviderFactory::Segment{".", "volume"});
-        auto lhs_provider2 = factory.createProviders(segments);
-
-        //entity.bbox.volume = 48
-        ComparePredicate compPred2(lhs_provider2, new FixedElementProvider(48.0f), ComparePredicate::Comparator::EQUALS);
-        assert(compPred2.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume = 1
-        ComparePredicate compPred3(lhs_provider2, new FixedElementProvider(1.0f), ComparePredicate::Comparator::EQUALS);
-        assert(!compPred3.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume != 1
-        ComparePredicate compPred4(lhs_provider2, new FixedElementProvider(1.0f), ComparePredicate::Comparator::NOT_EQUALS);
-        assert(compPred4.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume > 0
-        ComparePredicate compPred5(lhs_provider2, new FixedElementProvider(0.0f), ComparePredicate::Comparator::GREATER);
-        assert(compPred5.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume >= 1
-        ComparePredicate compPred6(lhs_provider2, new FixedElementProvider(1.0f), ComparePredicate::Comparator::GREATER_EQUAL);
-        assert(compPred6.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume < 5
-        ComparePredicate compPred7(lhs_provider2, new FixedElementProvider(5.0f), ComparePredicate::Comparator::LESS);
-        assert(!compPred7.isMatch(QueryContext{b1}));
-
-        //entity.bbox.volume <= 48
-        ComparePredicate compPred8(lhs_provider2, new FixedElementProvider(48.0f), ComparePredicate::Comparator::LESS_EQUAL);
-        assert(compPred8.isMatch(QueryContext{b1}));
-
-        //entity.type = types.barrel && entity.bbox.volume = 48
-        AndPredicate andPred1(&compPred1, &compPred2);
-        assert(andPred1.isMatch(QueryContext{b1}));
-
-        //entity.type = types.barrel && entity.bbox.volume = 1
-        AndPredicate andPred2(&compPred1, &compPred3);
-        assert(!andPred2.isMatch(QueryContext{b1}));
-
-        //entity.type = types.barrel || entity.bbox.volume = 1
-        OrPredicate orPred1(&compPred1, &compPred3);
-        assert(orPred1.isMatch(QueryContext{b1}));
-
-        //entity.float_list
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment { "", "entity" });
-        segments.push_back(ProviderFactory::Segment { ".", "float_list" });
-        auto lhs_provider3 = factory.createProviders(segments);
-
-        //entity.float_list contains 20.0
-        ComparePredicate compPred9(lhs_provider3, new FixedElementProvider(20.0), ComparePredicate::Comparator::CONTAINS);
-        assert(compPred9.isMatch(QueryContext{bl1}));
-
-        //20.0 in entity.float_list
-        ComparePredicate compPred13(new FixedElementProvider(20.0), lhs_provider3, ComparePredicate::Comparator::IN);
-        assert(compPred13.isMatch(QueryContext{bl1}));
-
-        //entity.float_list contains 100.0
-        ComparePredicate compPred10(lhs_provider3, new FixedElementProvider(100.0), ComparePredicate::Comparator::CONTAINS);
-        assert(!compPred10.isMatch(QueryContext{bl1}));
-
-        //100.0 in entity.float_list
-        ComparePredicate compPred14(new FixedElementProvider(100.0), lhs_provider3, ComparePredicate::Comparator::IN);
-        assert(!compPred14.isMatch(QueryContext{bl1}));
-
-        //entity.string_list
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment { "", "entity" });
-        segments.push_back(ProviderFactory::Segment { ".", "string_list" });
-        auto lhs_provider4 = factory.createProviders(segments);
-
-        //entity.string_list contains "foo"
-        ComparePredicate compPred11(lhs_provider4, new FixedElementProvider("foo"), ComparePredicate::Comparator::CONTAINS);
-        assert(compPred11.isMatch(QueryContext{bl1}));
-
-        //entity.string_list contains "foobar"
-        ComparePredicate compPred12(lhs_provider4, new FixedElementProvider("foobar"), ComparePredicate::Comparator::CONTAINS);
-        assert(!compPred12.isMatch(QueryContext{bl1}));
-
-        //self.type
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment { "", "self" });
-        segments.push_back(ProviderFactory::Segment { ".", "mass" });
-        auto lhs_provider5 = factory.createProviders(segments);
-        QueryContext qc{bl1};
-        qc.self_entity = &b1;
-
-        lhs_provider5->value(value, qc);
-        assert(value == Element(30));
-
-        //MindProviderFactory tests
-        MindProviderFactory mind_factory;
-
-        //memory.disposition
-        segments.clear();
-        segments.push_back({"", "memory"});
-        segments.push_back({".", "disposition"});
-        provider = mind_factory.createProviders(segments);
-        provider->value(value, QueryContext{b1, memory});
-        assert(value.Int() == 25);
-
-        //entity.memory
-        segments.clear();
-        segments.push_back({"", "memory"});
-        segments.push_back({".", "disposition"});
-        lhs_provider5 = mind_factory.createProviders(segments);
-
-        ComparePredicate compPred15(lhs_provider5, new FixedElementProvider(25), ComparePredicate::Comparator::EQUALS);
-        assert(compPred15.isMatch(QueryContext{b1, memory}));
-
-        //entity.type.name
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "type"});
-        segments.push_back(ProviderFactory::Segment{".", "name"});
-        auto lhs_provider6 = mind_factory.createProviders(segments);
-        ComparePredicate compPred16(lhs_provider6, new FixedElementProvider("barrel"), ComparePredicate::Comparator::EQUALS);
-        assert(compPred15.isMatch(QueryContext{b1, memory}));
-
-        //TESTS FOR contains_recursive FUNCTION
-        //entity.contains
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "entity"});
-        segments.push_back(ProviderFactory::Segment{".", "contains"});
-        auto lhs_provider7 = factory.createProviders(segments);
-
-        //types.boulder
-        segments.clear();
-        segments.push_back(ProviderFactory::Segment{"", "types"});
-        segments.push_back(ProviderFactory::Segment{".", "boulder"});
-        auto rhs_provider = factory.createProviders(segments);
-
-        //lhs_provider1 = entity.type
-        ComparePredicate compPred17(lhs_provider1, rhs_provider, ComparePredicate::Comparator::EQUALS);
-
-        ContainsRecursiveFunctionProvider contains_recursive(lhs_provider7, &compPred17);
-        contains_recursive.value(value, QueryContext{b1});
-        assert(value.Int() == 1);
-
-        contains_recursive.value(value, QueryContext{b2});
-        assert(value.Int() == 0);
-
-        //rhs_provider1 = types.barrel
-        ComparePredicate compPred18(lhs_provider1, rhs_provider1, ComparePredicate::Comparator::EQUALS);
-        ContainsRecursiveFunctionProvider contains_recursive2(lhs_provider7, &compPred18);
-
-        contains_recursive2.value(value, QueryContext{b1});
-        assert(value.Int() == 1);
-
-        contains_recursive2.value(value, QueryContext{bl1});
-        assert(value.Int() == 1);
-
-        contains_recursive2.value(value, QueryContext{b2});
-        assert(value.Int() == 0);
-
-        contains_recursive2.value(value, QueryContext{b3});
-        assert(value.Int() == 0);
-        //END OF contains_recursive TESTS
-
+    for (auto iter = entitiesToFail.begin(); iter != entitiesToFail.end();
+            ++iter) {
+        ASSERT_TRUE(!f.match(**iter));
     }
+}
 
+void EntityFilterTest::teardown()
+{
 //    Clean up
-    delete barrelType;
-    delete boulderType;
-    delete glovesType;
-    delete bootsType;
-    delete characterType;
+    delete m_b1;
+    delete m_b2;
+    delete m_b3;
+    delete m_bl1;
+    delete m_ch1;
+    delete m_cloth;
+    delete m_leather;
+    delete m_glovesEntity;
+
+    delete m_barrelType;
+    delete m_boulderType;
+    delete m_glovesType;
+    delete m_bootsType;
+    delete m_characterType;
+
 }
 
 //Stubs
-
 
 #include "stubs/common/stubVariable.h"
 #include "stubs/common/stubMonitors.h"
@@ -740,8 +778,9 @@ void Location::modifyBBox()
 {
 }
 
-
-Inheritance::Inheritance() {}
+Inheritance::Inheritance()
+{
+}
 
 Inheritance & Inheritance::instance()
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,7 +58,8 @@ RULESETS_TESTS = LocatedEntitytest Entitytest Planttest \
                  ArithmeticFactorytest PythonArithmeticFactorytest \
                  TerrainModtest PythonClasstest \
                  TerrainEffectorPropertytest SuspendedPropertytest \
-                 EntityFiltertest
+                 EntityFiltertest EntityFilterParsertest \
+                 EntityFilterProviderstest
 
 RULESETS_INTEGRATION_TESTS = MindPropertyintegration \
                              TerrainPropertyintegration \
@@ -1003,6 +1004,32 @@ TerrainEffectorPropertytest_LDADD = \
         $(TERRAIN_LIBS)
 
 EntityFiltertest_SOURCES = EntityFiltertest.cpp
+EntityFiltertest_LDADD = \
+        $(top_builddir)/rulesets/libentityfilter.a \
+        $(top_builddir)/rulesets/EntityProperty.o \
+        $(top_builddir)/rulesets/Entity.o \
+        $(top_builddir)/rulesets/OutfitProperty.o \
+        $(top_builddir)/rulesets/BBoxProperty.o \
+        $(top_builddir)/rulesets/LocatedEntity.o \
+        $(top_builddir)/modules/EntityRef.o \
+        $(top_builddir)/common/Property.o \
+        $(top_builddir)/common/TypeNode.o \
+        $(top_builddir)/common/PropertyManager.o
+        
+EntityFilterParsertest_SOURCES = EntityFilterParsertest.cpp
+EntityFiltertest_LDADD = \
+        $(top_builddir)/rulesets/libentityfilter.a \
+        $(top_builddir)/rulesets/EntityProperty.o \
+        $(top_builddir)/rulesets/Entity.o \
+        $(top_builddir)/rulesets/OutfitProperty.o \
+        $(top_builddir)/rulesets/BBoxProperty.o \
+        $(top_builddir)/rulesets/LocatedEntity.o \
+        $(top_builddir)/modules/EntityRef.o \
+        $(top_builddir)/common/Property.o \
+        $(top_builddir)/common/TypeNode.o \
+        $(top_builddir)/common/PropertyManager.o
+        
+EntityFilterProviderstest_SOURCES = EntityFilterProviderstest.cpp
 EntityFiltertest_LDADD = \
         $(top_builddir)/rulesets/libentityfilter.a \
         $(top_builddir)/rulesets/EntityProperty.o \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1017,7 +1017,7 @@ EntityFiltertest_LDADD = \
         $(top_builddir)/common/PropertyManager.o
         
 EntityFilterParsertest_SOURCES = EntityFilterParsertest.cpp
-EntityFiltertest_LDADD = \
+EntityFilterParsertest_LDADD = \
         $(top_builddir)/rulesets/libentityfilter.a \
         $(top_builddir)/rulesets/EntityProperty.o \
         $(top_builddir)/rulesets/Entity.o \
@@ -1030,7 +1030,7 @@ EntityFiltertest_LDADD = \
         $(top_builddir)/common/PropertyManager.o
         
 EntityFilterProviderstest_SOURCES = EntityFilterProviderstest.cpp
-EntityFiltertest_LDADD = \
+EntityFilterProviderstest_LDADD = \
         $(top_builddir)/rulesets/libentityfilter.a \
         $(top_builddir)/rulesets/EntityProperty.o \
         $(top_builddir)/rulesets/Entity.o \


### PR DESCRIPTION
Hey.

This pull request should contain the changes I've made to the tests so far.

These might not be all possible and most comprehensive tests I could make, but they are at least as comprehensive as the old tests, while also being more modular, clearer and easier to maintain.

Feel free to review the changes and provide suggestions/feedback.

A few of my thoughts were: make a general test class for filters with common setUp and teardown functions and then inherit specific tests (parser, provider and filter tests) from that class. I don't know how viable this is.

Another issue were the built in assertion macros (like ASSERT_TRUE, ASSERT_EQUAL, etc.). When I used them, they seemed to have interrupted specific tests upon failure and have written an appropriate message into the [test].log file, but the test suite reported that all tests have passed. On the other hand, if you use a built-in assertion, the test suite will report an error during make check. Not sure if that's the intended behavior.


Yaroslav