### PR TITLE
EntityFilter not operator and instance_of fix

### DIFF
--- a/rulesets/entityfilter/Predicates.cpp
+++ b/rulesets/entityfilter/Predicates.cpp
@@ -184,4 +184,14 @@ bool OrPredicate::isMatch(const QueryContext& context) const
     return m_lhs->isMatch(context) || m_rhs->isMatch(context);
 
 }
+
+NotPredicate::NotPredicate(const Predicate* pred) :
+        m_pred(pred)
+{
+}
+
+bool NotPredicate::isMatch(const QueryContext& context) const
+{
+    return !m_pred->isMatch(context);
+}
 }

--- a/rulesets/entityfilter/Predicates.cpp
+++ b/rulesets/entityfilter/Predicates.cpp
@@ -125,7 +125,7 @@ bool ComparePredicate::isMatch(const QueryContext& context) const
                     const TypeNode* rightType =
                             static_cast<const TypeNode*>(right.Ptr());
                     if (rightType) {
-                        return rightType->isTypeOf(leftType);
+                        return leftType->isTypeOf(rightType);
                     }
                 }
             }

--- a/rulesets/entityfilter/Predicates.h
+++ b/rulesets/entityfilter/Predicates.h
@@ -50,6 +50,14 @@ class OrPredicate : public Predicate {
         const Predicate* m_lhs;
         const Predicate* m_rhs;
 };
+
+class NotPredicate : public Predicate {
+    public:
+        NotPredicate(const Predicate* pred);
+        virtual bool isMatch(const QueryContext& context) const;
+    protected:
+        const Predicate* m_pred;
+};
 }
 
 #endif

--- a/tests/EntityFilterParsertest.cpp
+++ b/tests/EntityFilterParsertest.cpp
@@ -135,6 +135,16 @@ void ParserTest::test_LogicalOperators()
     pred = ConstructPredicate("1 = 2 and 3 = 4");
     assert(typeid(*pred) == typeid(AndPredicate));
     delete pred;
+
+    pred = ConstructPredicate("!5 = 6");
+    assert(typeid(*pred) == typeid(NotPredicate));
+
+    pred = ConstructPredicate("not 7 = 8");
+    assert(typeid(*pred) == typeid(NotPredicate));
+
+    //Test precedence. not should be applied to 1 = 2, not the whole expression
+    pred = ConstructPredicate("not 1 = 2 and 3 = 4");
+    assert(typeid(*pred) == typeid(AndPredicate));
 }
 
 void ParserTest::test_Literals()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -49,6 +49,7 @@ class ProvidersTest : public Cyphesis::TestBase {
         Entity *m_cloth; //Cloth for gloves' outfit
 
         //Types for testing
+        TypeNode *m_thingType;
         TypeNode *m_barrelType;
         TypeNode *m_characterType;
         TypeNode *m_clothType;
@@ -332,9 +333,14 @@ ProvidersTest::ProvidersTest()
 
 void ProvidersTest::setup()
 {
+    //Thing is a parent type for all types except character
+    m_thingType = new TypeNode("thing");
+    types["thing"] = m_thingType;
+
     //Make a barrel with mass and burn speed properties
     m_b1 = new Entity("1", 1);
     m_barrelType = new TypeNode("barrel");
+    m_barrelType->setParent(m_thingType);
     types["barrel"] = m_barrelType;
     m_b1->setType(m_barrelType);
     m_b1->setProperty("mass", new SoftProperty(Element(30)));
@@ -376,6 +382,7 @@ void ProvidersTest::setup()
 
     //Green Cloth serves as outfit for gloves
     m_clothType = new TypeNode("cloth");
+    m_clothType->setParent(m_thingType);
     types["cloth"] = m_clothType;
 
     m_cloth = new Entity("3", 3);
@@ -419,6 +426,7 @@ void ProvidersTest::teardown()
     delete m_barrelType;
     delete m_characterType;
     delete m_clothType;
+    delete m_thingType;
 }
 
 Consumer<QueryContext>* ProvidersTest::CreateProvider(std::initializer_list<

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -79,6 +79,9 @@ class ProvidersTest : public Cyphesis::TestBase {
         ///\contains_recursive(container, condition) checks if there is an entity
         ///\that matches condition within the container
         void test_ContainsRecursive();
+        ///\Test instance_of operator
+        ///\In particular, cases of checking for parent type
+        void test_InstanceOf();
 
 };
 
@@ -176,7 +179,6 @@ void ProvidersTest::test_ComparePredicates()
 
     ComparePredicate compPred1(lhs_provider1, rhs_provider1,
                                ComparePredicate::Comparator::INSTANCE_OF);
-    assert(compPred1.isMatch(QueryContext { *m_b1 }));
 
     //entity.bbox.volume
     auto lhs_provider2 = CreateProvider( { "entity", "bbox", "volume" });
@@ -322,6 +324,31 @@ void ProvidersTest::test_ContainsRecursive()
     assert(value.Int() == 0);
 }
 
+void ProvidersTest::test_InstanceOf()
+{
+    //Thing for testing instance_of
+    Entity thingEntity("123", 123);
+    thingEntity.setType(m_thingType);
+
+    //Barrel is also thing but thing is not a barrel
+
+    //entity.type = types.barrel
+    auto lhs_provider1 = CreateProvider( { "entity", "type" });
+    auto rhs_provider1 = CreateProvider( { "types", "barrel" });
+
+    ComparePredicate compPred1(lhs_provider1, rhs_provider1,
+                               ComparePredicate::Comparator::INSTANCE_OF);
+    ASSERT_TRUE(compPred1.isMatch(QueryContext { *m_b1 }));
+    ASSERT_TRUE(!compPred1.isMatch(QueryContext { thingEntity }));
+
+    auto rhs_provider2 = CreateProvider( { "types", "thing" });
+
+    ComparePredicate compPred2(lhs_provider1, rhs_provider2,
+                               ComparePredicate::Comparator::INSTANCE_OF);
+    ASSERT_TRUE(compPred2.isMatch(QueryContext { *m_b1 }));
+    ASSERT_TRUE(compPred2.isMatch(QueryContext { thingEntity }));
+}
+
 ProvidersTest::ProvidersTest()
 {
     ADD_TEST(ProvidersTest::test_EntityProperty);
@@ -329,6 +356,7 @@ ProvidersTest::ProvidersTest()
     ADD_TEST(ProvidersTest::test_OutfitProviders);
     ADD_TEST(ProvidersTest::test_ComparePredicates);
     ADD_TEST(ProvidersTest::test_ListComparators);
+    ADD_TEST(ProvidersTest::test_InstanceOf);
 }
 
 void ProvidersTest::setup()

--- a/tests/EntityFilterProviderstest.cpp
+++ b/tests/EntityFilterProviderstest.cpp
@@ -226,6 +226,10 @@ void ProvidersTest::test_ComparePredicates()
     //entity.type = types.barrel || entity.bbox.volume = 1
     OrPredicate orPred1(&compPred1, &compPred3);
     assert(orPred1.isMatch(QueryContext { *m_b1 }));
+
+    //not entity.type = types.barrel
+    NotPredicate notPred1(&compPred1);
+    assert(orPred1.isMatch((QueryContext { *m_b1 })));
 }
 
 void ProvidersTest::test_ListComparators()

--- a/tests/EntityFiltertest.cpp
+++ b/tests/EntityFiltertest.cpp
@@ -197,6 +197,11 @@ void EntityFilterTest::test_LogicalOperators()
                       m_b1, m_b2, m_bl1 },
               { });
 
+    //test not operator
+    TestQuery("!entity.type = types.barrel", { m_bl1 }, { m_b1, m_b2 });
+
+    TestQuery("not entity.burn_speed = 0.3", { m_bl1 }, { m_b1 });
+
     //test multiple types for instance_of operator
     TestQuery("entity.type instance_of types.barrel|types.boulder", { m_b1,
                       m_bl1 },
@@ -218,6 +223,12 @@ void EntityFilterTest::test_LogicalOperators()
     TestQuery(
             "entity.type=types.boulder||entity.type=types.barrel&&entity.burn_speed=0.3",
             { m_b1, m_bl1 }, { });
+
+    //Test not operator precedence. It should be applied to burn_speed comparison, and
+    //not the whole expression
+    TestQuery("not entity.burn_speed = 0.3 && entity.type=types.barrel", { m_b2,
+                      m_b3 },
+              { m_b1, m_bl1 });
 
 }
 
@@ -247,6 +258,9 @@ void EntityFilterTest::test_Parentheses()
     TestQuery(
             "(entity.type=types.boulder||entity.type=types.barrel)&&entity.burn_speed=0.3",
             { m_b1 }, { m_bl1 });
+    TestQuery("not (entity.burn_speed = 0.3 && entity.type=types.barrel)", {
+                      m_bl1, m_b3, m_b2 },
+              { m_b1 });
 }
 
 void EntityFilterTest::test_Outfit()


### PR DESCRIPTION
Hey.
This pull request includes a minor change to instance_of operator (simply swapped the operands so that we compare whether left side is instance_of right side, and not vice versa).

As well as an addition of not operator. It works similarly to other operators, except that it's an unary operator. It's still counted as a logical operator and is parsed so that it takes highest precedence (i.e. in a query "not 1 = 2 and 3 = 4", not is applied to 1=2 and not the whole expression, unless specified using parentheses.

You can review this and let me know if you have any questions.