### PR TITLE
Remove obsolete buildID system

### DIFF
--- a/common/const.cpp
+++ b/common/const.cpp
@@ -30,8 +30,5 @@ namespace consts {
   const long rootWorldIntId = 0L;
   // Version of the software we are running
   const char * version = PACKAGE_VERSION;
-  // Time this server was built
-  // const char * buildTime = __TIME__;
-  // const char * buildDate = __DATE__;
 
 }

--- a/common/const.h
+++ b/common/const.h
@@ -66,11 +66,7 @@ namespace consts {
   extern const long rootWorldIntId;
   /// \brief Version of the software we are running
   extern const char * version;
-  /// \brief Time this server was built
-  extern const char * buildTime;
-  /// \brief Date this server was built
-  extern const char * buildDate;
-  /// \brief Identifier of this build, taken from "git describe".
+  /// \brief Identifier of this build, taken from "git rev-parse".
   extern const char * buildId;
 
   // @}

--- a/man/cycmd.1
+++ b/man/cycmd.1
@@ -179,7 +179,6 @@ the lobby to see if any users are logged in.
 .nf
 cyphesis> stat
 Info(
-     builddate:  11:32:45, Sep 27 2004
      clients:  1
      name:  calcitration.ecs.soton.ac.uk
      objtype:  obj

--- a/man/cycmd.sgml
+++ b/man/cycmd.sgml
@@ -451,7 +451,6 @@ the lobby to see if any users are logged in.
   <programlisting>
 cyphesis> stat
 Info(
-     builddate:  11:32:45, Sep 27 2004
      clients:  1
      name:  calcitration.ecs.soton.ac.uk
      objtype:  obj

--- a/scripts/extract_revision.sh
+++ b/scripts/extract_revision.sh
@@ -2,7 +2,6 @@
 
 TOPSRCDIR="$@"
 GITCHECK="${TOPSRCDIR}/.git/config"
-OLDBUILDCPP="${TOPSRCDIR}/server/buildid.cpp"
 
 if ! test -d "${TOPSRCDIR}"
 then
@@ -11,27 +10,17 @@ then
     exit 1
 fi
 
-# If sources are under git control then use "git describe"
+# If sources are under Git version control then use "git rev-parse"
 if test -f "${GITCHECK}"
 then
-    if (cd "${TOPSRCDIR}" && git describe)
+    if (cd "${TOPSRCDIR}" && git rev-parse HEAD)
     then
         echo Getting buildid from Git >&2
         exit 0
     fi
 fi
 
-# We don't seem to be under source control, so use the existing buildid.
-if test -f "${OLDBUILDCPP}"
-then
-    if grep buildId "${OLDBUILDCPP}" | head -n 1 | sed "s/^.* = \([-0-9]*\);$/\1/"
-    then
-        echo Using existing buildid >&2
-        exit 0
-    fi
-fi
-
-# We could not find any useful build ID, so mark it clearly as an error.
-echo Unknown buildid >&2
-echo 1
+# Not in Git version control, therefore this is a released build.
+echo Released build, no SHA1 buildid. >&2
+echo Released
 exit 0

--- a/scripts/gen_buildid.py
+++ b/scripts/gen_buildid.py
@@ -12,12 +12,8 @@ build_id.write(
 
 namespace consts {
 
-  const char * buildTime = __TIME__;
-  const char * buildDate = __DATE__;
   const char * buildId = "%s";
 }
 """ % sys.argv[1])
 
 build_id.close()
-
-# tail -n 1 ChangeLog | sed "s/^.* 1\.\([0-9]*\).*$/\1/"

--- a/server/CommMDNSPublisher.cpp
+++ b/server/CommMDNSPublisher.cpp
@@ -341,9 +341,6 @@ void CommMDNSPublisher::setup_service(AvahiClient * client)
 
     AvahiStringList * txt;
     txt = avahi_string_list_new(
-      String::compose("builddate=%1",
-                      std::string(consts::buildTime) + ", " +
-                      std::string(consts::buildDate)).c_str(),
       String::compose("clients=%1", m_server.getClients()).c_str(),
       String::compose("ruleset=%1", m_server.getRuleset()).c_str(),
       String::compose("server=%1", "cyphesis").c_str(),

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -154,7 +154,7 @@ cyprox_LDADD = libcomm.a \
                $(FRONTEND_LIBS)
 
 buildid.cpp: $(SERVER_SOURCES) $(LOCAL_LIBS) \
-             $(top_srcdir)/scripts/gen_buildid.py $(top_srcdir)/ChangeLog
+             $(top_srcdir)/scripts/gen_buildid.py
 	$(top_srcdir)/scripts/gen_buildid.py `$(top_srcdir)/scripts/extract_revision.sh $(top_srcdir)` buildid.cpp
 
 cyslave_SOURCES = \

--- a/server/ServerRouting.cpp
+++ b/server/ServerRouting.cpp
@@ -60,9 +60,6 @@ ServerRouting::ServerRouting(BaseWorld & wrld,
 {
     Monitors * monitors = Monitors::instance();
     monitors->insert("server", "cyphesis");
-    monitors->insert("builddate", String::compose("%1, %2",
-                                                  consts::buildDate,
-                                                  consts::buildTime));
     monitors->watch("instance", new Variable<std::string>(::instance));
     monitors->watch("name", new Variable<std::string>(m_svrName));
     monitors->watch("ruleset", new Variable<std::string>(m_svrRuleset));
@@ -153,7 +150,6 @@ void ServerRouting::addToMessage(MapType & omap) const
     omap["parents"] = ListType(1, "server");
     omap["clients"] = m_numClients;
     omap["uptime"] = m_world.upTime();
-    omap["builddate"] = std::string(consts::buildTime)+", "+std::string(consts::buildDate);
     omap["buildid"] = consts::buildId;
     omap["version"] = std::string(consts::version);
     if (restricted_flag) {
@@ -173,7 +169,6 @@ void ServerRouting::addToEntity(const RootEntity & ent) const
     ent->setParents(std::list<std::string>(1, "server"));
     ent->setAttr("clients", m_numClients);
     ent->setAttr("uptime", m_world.upTime());
-    ent->setAttr("builddate", std::string(consts::buildTime)+", "+std::string(consts::buildDate));
     ent->setAttr("buildid", consts::buildId);
     ent->setAttr("version", std::string(consts::version));
     if (restricted_flag) {

--- a/server/frontend.cpp
+++ b/server/frontend.cpp
@@ -68,7 +68,7 @@ int main(int argc, char ** argv)
     if (config_status < 0) {
         if (config_status == CONFIG_VERSION) {
             std::cout << argv[0] << " (cyphesis) " << consts::version
-                      << " (Cyphesis build " << consts::buildId << ")"
+                      << " (Cyphesis build: " << consts::buildId << ")"
                       << std::endl << std::flush;
 
             return 0;

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -164,7 +164,7 @@ int main(int argc, char ** argv)
     if (config_status < 0) {
         if (config_status == CONFIG_VERSION) {
             std::cout << argv[0] << " (cyphesis) " << consts::version
-                    << " (Cyphesis build " << consts::buildId << ")"
+                    << " (Cyphesis build: " << consts::buildId << ")"
                     << std::endl << std::flush;
 
             return 0;

--- a/tests/CommMDNSPublisherTest.cpp
+++ b/tests/CommMDNSPublisherTest.cpp
@@ -125,8 +125,6 @@ void log(LogLevel lvl, const std::string & msg)
 
 namespace consts {
 
-  const char * buildTime = __TIME__;
-  const char * buildDate = __DATE__;
   const int buildId = -1;
   const char * version = "test_version";
 }

--- a/tests/buildidTest.cpp
+++ b/tests/buildidTest.cpp
@@ -36,8 +36,6 @@ class buildidtest : public Cyphesis::TestBase
   public:
     buildidtest()
     {
-        ADD_TEST(buildidtest::test_time);
-        ADD_TEST(buildidtest::test_date);
         ADD_TEST(buildidtest::test_id);
     }
 
@@ -49,20 +47,8 @@ class buildidtest : public Cyphesis::TestBase
     {
     }
 
-    void test_time();
-    void test_date();
     void test_id();
 };
-
-void buildidtest::test_time()
-{
-    ASSERT_GREATER(strlen(consts::buildTime), 0u);
-}
-
-void buildidtest::test_date()
-{
-    ASSERT_GREATER(strlen(consts::buildDate), 0u);
-}
 
 void buildidtest::test_id()
 {

--- a/tests/constTest.cpp
+++ b/tests/constTest.cpp
@@ -80,23 +80,5 @@ int main()
     versions = consts::version;
     assert(versions.size() > 0);
 
-#if 0
-// For the time being, as these are now in the server/buildid.cpp
-// we are leaving the out
-    const char * buildTime;
-    buildTime = consts::buildTime;
-    assert(buildTime != 0);
-    std::string buildTimes;
-    buildTimes = consts::buildTime;
-    assert(buildTimes.size() > 0);
-
-    const char * buildDate;
-    buildDate = consts::buildDate;
-    assert(buildDate != 0);
-    std::string buildDates;
-    buildDates = consts::buildDate;
-    assert(buildDates.size() > 0);
-#endif
-
     return 0;
 }

--- a/tests/stubs/server/stubBuildid.h
+++ b/tests/stubs/server/stubBuildid.h
@@ -2,7 +2,5 @@
 
 namespace consts {
 
-  const char * buildTime = __TIME__;
-  const char * buildDate = __DATE__;
   const char * buildId = "test";
 }


### PR DESCRIPTION
The __TIME__ and __DATE__ macros were interfering with reproducible builds.